### PR TITLE
Fix: Interactive templates taking time to load

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@glific/flow-editor",
   "license": "AGPL-3.0",
   "repository": "git://github.com/glific/floweditor.git",
-  "version": "1.26.3-14",
+  "version": "1.26.3-15",
   "description": "'Standalone flow editing tool designed for use within the Glific suite of messaging tools'",
   "browser": "umd/flow-editor.min.js",
   "unpkg": "umd/flow-editor.min.js",

--- a/src/components/flow/actions/sendinteractivemsg/SendInteractiveMsgForm.tsx
+++ b/src/components/flow/actions/sendinteractivemsg/SendInteractiveMsgForm.tsx
@@ -62,6 +62,7 @@ export default class SendMsgForm extends React.Component<
   };
 
   private handleInteractivesChanged(selected: any[]): void {
+    const { endpoint, type } = this.props.assetStore.interactives;
     const interactiveMsg = selected ? selected[0] : null;
     if (interactiveMsg.name === 'Expression') {
       this.setState({
@@ -71,13 +72,17 @@ export default class SendMsgForm extends React.Component<
         }
       });
     } else {
-      this.setState({
-        expression: null,
-        interactives: {
-          value: interactiveMsg
-        },
-        isChecked: false
-      });
+      if (interactiveMsg) {
+        getAsset(endpoint, type, interactiveMsg.id).then(response => {
+          this.setState({
+            expression: null,
+            interactives: {
+              value: response
+            },
+            isChecked: false
+          });
+        });
+      }
     }
   }
 


### PR DESCRIPTION
While fetching list of interactive templates, it takes a lot of time to load because be are also fetching translations in the list api.
Instead now we will fetch translations from the ` interactive-template` api