### PR TITLE
Fix for duplicate labels

### DIFF
--- a/src/components/flow/actions/addlabels/AddLabels.tsx
+++ b/src/components/flow/actions/addlabels/AddLabels.tsx
@@ -10,20 +10,22 @@ const AddLabelsComp: React.SFC<AddLabels> = ({ labels }, context: any): JSX.Elem
   return (
     <>
       {renderAssetList(
-        labels.map(label => {
-          if (label.name_match) {
+        labels
+          .filter(label => !label.arbitrary)
+          .map(label => {
+            if (label.name_match) {
+              return {
+                id: label.name_match,
+                name: label.name_match,
+                type: AssetType.NameMatch
+              };
+            }
             return {
-              id: label.name_match,
-              name: label.name_match,
-              type: AssetType.NameMatch
+              id: label.uuid,
+              name: label.name,
+              type: AssetType.Label
             };
-          }
-          return {
-            id: label.uuid,
-            name: label.name,
-            type: AssetType.Label
-          };
-        }),
+          }),
         MAX_TO_SHOW,
         context.config.endpoints
       )}

--- a/src/components/flow/actions/addlabels/helpers.ts
+++ b/src/components/flow/actions/addlabels/helpers.ts
@@ -9,12 +9,14 @@ export const initializeForm = (settings: NodeEditorSettings): AddLabelsFormState
     const action = settings.originalAction as AddLabels;
     return {
       labels: {
-        value: action.labels.map((label: Label) => {
-          if (label.name_match) {
-            return { name: label.name_match, expression: true };
-          }
-          return label;
-        })
+        value: action.labels
+          .filter((label: Label) => !label.arbitrary)
+          .map((label: Label) => {
+            if (label.name_match) {
+              return { name: label.name_match, expression: true };
+            }
+            return label;
+          })
       },
       valid: true
     };

--- a/src/components/flow/actions/sendinteractivemsg/SendInteractiveMsg.tsx
+++ b/src/components/flow/actions/sendinteractivemsg/SendInteractiveMsg.tsx
@@ -70,20 +70,22 @@ const SendInteractiveMsgComp: React.SFC<SendInteractiveMsg> = ({
 
   if (labels) {
     labelsList = renderAssetList(
-      labels.map((label: any) => {
-        if (label.name_match) {
+      labels
+        .filter(label => !label.arbitrary)
+        .map((label: any) => {
+          if (label.name_match) {
+            return {
+              id: label.name_match,
+              name: label.name_match,
+              type: AssetType.NameMatch
+            };
+          }
           return {
-            id: label.name_match,
-            name: label.name_match,
-            type: AssetType.NameMatch
+            id: label.uuid,
+            name: label.name,
+            type: AssetType.Label
           };
-        }
-        return {
-          id: label.uuid,
-          name: label.name,
-          type: AssetType.Label
-        };
-      }),
+        }),
       MAX_TO_SHOW,
       endpoints
     );

--- a/src/components/flow/actions/sendinteractivemsg/helpers.tsx
+++ b/src/components/flow/actions/sendinteractivemsg/helpers.tsx
@@ -19,12 +19,14 @@ export const initializeForm = (settings: NodeEditorSettings): SendInteractiveMsg
     const interactive_content = JSON.parse(action.text);
 
     const labels = action.labels
-      ? action.labels.map((label: Label) => {
-          if (label.name_match) {
-            return { name: label.name_match, expression: true };
-          }
-          return label;
-        })
+      ? action.labels
+          .filter((label: Label) => !label.arbitrary)
+          .map((label: Label) => {
+            if (label.name_match) {
+              return { name: label.name_match, expression: true };
+            }
+            return label;
+          })
       : [];
 
     const listValues = params

--- a/src/components/flow/actions/sendmsg/SendMsg.tsx
+++ b/src/components/flow/actions/sendmsg/SendMsg.tsx
@@ -16,20 +16,22 @@ const SendMsgComp: React.SFC<SendMsg> = (action: SendMsg): JSX.Element => {
 
   if (action.labels) {
     labels = renderAssetList(
-      action.labels.map((label: any) => {
-        if (label.name_match) {
+      action.labels
+        .filter(label => !label.arbitrary)
+        .map((label: any) => {
+          if (label.name_match) {
+            return {
+              id: label.name_match,
+              name: label.name_match,
+              type: AssetType.NameMatch
+            };
+          }
           return {
-            id: label.name_match,
-            name: label.name_match,
-            type: AssetType.NameMatch
+            id: label.uuid,
+            name: label.name,
+            type: AssetType.Label
           };
-        }
-        return {
-          id: label.uuid,
-          name: label.name,
-          type: AssetType.Label
-        };
-      }),
+        }),
       MAX_TO_SHOW,
       endpoints
     );

--- a/src/components/flow/actions/sendmsg/helpers.ts
+++ b/src/components/flow/actions/sendmsg/helpers.ts
@@ -60,12 +60,14 @@ export const initializeForm = (
     }
 
     const labels = action.labels
-      ? action.labels.map((label: Label) => {
-          if (label.name_match) {
-            return { name: label.name_match, expression: true };
-          }
-          return label;
-        })
+      ? action.labels
+          .filter((label: Label) => !label.arbitrary)
+          .map((label: Label) => {
+            if (label.name_match) {
+              return { name: label.name_match, expression: true };
+            }
+            return label;
+          })
       : [];
 
     return {

--- a/src/flowTypes.ts
+++ b/src/flowTypes.ts
@@ -305,6 +305,7 @@ export interface Label {
   uuid: string;
   name: string;
   name_match?: string;
+  arbitrary?: boolean;
 }
 
 export interface OptIn {


### PR DESCRIPTION
A flow in sarc's instance was facing this duplicate labels issue, which persisted even on importing the [flow](https://prod.glific.com/flow/configure/1aaeba0c-ff2d-4223-81c6-f352164be81c) in prod.

On debugging i found out the labels array has this object
`{
              "id": "created",
              "name": "academic_details",
              "prefix": "Create Label: ",
              "arbitrary": true
},`

because of which it was creating the label again and again on every change as it was going in if block of this code block
<img width="590" alt="image" src="https://github.com/user-attachments/assets/a840cb60-3ee1-47a6-b80a-b1b4bf78c200" />

This PR handles this edge case for all three nodes using labels(send msg, send interactive msg, and add labels) if it happens in the future.
