### PR TITLE
Added home tab in nodes and renamed WhatsApp to HSM Templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@glific/flow-editor",
   "license": "AGPL-3.0",
   "repository": "git://github.com/glific/floweditor.git",
-  "version": "1.26.3-28",
+  "version": "1.26.3-29",
   "description": "'Standalone flow editing tool designed for use within the Glific suite of messaging tools'",
   "browser": "umd/flow-editor.min.js",
   "unpkg": "umd/flow-editor.min.js",

--- a/src/components/dialog/Dialog.tsx
+++ b/src/components/dialog/Dialog.tsx
@@ -57,9 +57,16 @@ export default class Dialog extends React.Component<DialogProps, DialogState> {
 
   constructor(props: DialogProps) {
     super(props);
-    this.state = {
-      activeTab: this.props.defaultTab !== null ? this.props.defaultTab : -1
-    };
+
+    if (this.props.tabs && this.props.tabs.length > 0) {
+      this.state = {
+        activeTab: this.props.tabs.length
+      };
+    } else {
+      this.state = {
+        activeTab: -1
+      };
+    }
 
     bindCallbacks(this, {
       include: [/^handle/, /^get/]
@@ -162,6 +169,15 @@ export default class Dialog extends React.Component<DialogProps, DialogState> {
   }
 
   public render(): JSX.Element {
+    const homeTab: Tab = {
+      name: 'Home',
+      body: <>{this.props.children}</>
+    };
+    let allTabs = [...(this.props.tabs || [])];
+    if (this.props.tabs && this.props.tabs.length > 0) {
+      allTabs = [...allTabs, homeTab];
+    }
+
     const headerClasses = [styles.header];
 
     if (this.state.activeTab > -1) {
@@ -205,9 +221,9 @@ export default class Dialog extends React.Component<DialogProps, DialogState> {
               <div className={styles.title}>{this.props.title}</div>
               <div className={styles.subtitle}>{this.props.subtitle}</div>
             </div>
-            {(this.props.tabs || []).length > 0 ? (
+            {allTabs.length > 0 ? (
               <div className={styles.tabs}>
-                {(this.props.tabs || []).map((tab: Tab, index: number) => (
+                {allTabs.map((tab: Tab, index: number) => (
                   <div
                     key={'tab_' + tab.name}
                     style={{ display: 'flex' }}
@@ -231,9 +247,7 @@ export default class Dialog extends React.Component<DialogProps, DialogState> {
         </div>
 
         <div className={this.props.noPadding ? '' : styles.content}>
-          {this.state.activeTab > -1
-            ? this.props.tabs![this.state.activeTab].body
-            : this.props.children}
+          {this.state.activeTab > -1 ? allTabs[this.state.activeTab].body : homeTab.body}
         </div>
 
         <div className={styles.footer}>

--- a/src/components/flow/actions/localization/MsgLocalizationForm.tsx
+++ b/src/components/flow/actions/localization/MsgLocalizationForm.tsx
@@ -275,7 +275,7 @@ export default class MsgLocalizationForm extends React.Component<
       const variable = i18n.t('forms.variable', 'Variable');
 
       tabs.push({
-        name: 'WhatsApp',
+        name: 'HSM Templates',
         body: (
           <>
             <p>

--- a/src/components/flow/actions/localization/__snapshots__/KeyLocalizationForm.test.tsx.snap
+++ b/src/components/flow/actions/localization/__snapshots__/KeyLocalizationForm.test.tsx.snap
@@ -24,8 +24,11 @@ exports[`KeyLocalizationForm removes translations 1`] = `
       class="dialog"
     >
       <div
-        class="header send_email"
+        class="header clickable send_email"
       >
+        <div
+          class="header_overlay"
+        />
         <div
           class="title_container"
         >
@@ -50,6 +53,14 @@ exports[`KeyLocalizationForm removes translations 1`] = `
             >
               <div>
                 Body Translation
+              </div>
+            </div>
+            <div
+              class="tab active"
+              style="display: flex;"
+            >
+              <div>
+                Home
               </div>
             </div>
           </div>
@@ -142,8 +153,11 @@ exports[`KeyLocalizationForm renders send email 1`] = `
       class="dialog"
     >
       <div
-        class="header send_email"
+        class="header clickable send_email"
       >
+        <div
+          class="header_overlay"
+        />
         <div
           class="title_container"
         >
@@ -168,6 +182,14 @@ exports[`KeyLocalizationForm renders send email 1`] = `
             >
               <div>
                 Body Translation
+              </div>
+            </div>
+            <div
+              class="tab active"
+              style="display: flex;"
+            >
+              <div>
+                Home
               </div>
             </div>
           </div>

--- a/src/components/flow/actions/sendmsg/SendMsgForm.tsx
+++ b/src/components/flow/actions/sendmsg/SendMsgForm.tsx
@@ -547,7 +547,7 @@ export default class SendMsgForm extends React.Component<ActionFormProps, SendMs
 
     if (hasFeature(this.context.config, FeatureFilter.HAS_WHATSAPP)) {
       const templates: Tab = {
-        name: 'WhatsApp',
+        name: 'HSM Templates',
         body: this.renderTemplateConfig(),
         checked: this.state.template.value != null,
         hasErrors:

--- a/src/components/flow/actions/sendmsg/__snapshots__/SendMsgForm.test.ts.snap
+++ b/src/components/flow/actions/sendmsg/__snapshots__/SendMsgForm.test.ts.snap
@@ -151,7 +151,7 @@ exports[`SendMsgForm render should render 1`] = `
         </React.Fragment>,
         "checked": false,
         "hasErrors": false,
-        "name": "WhatsApp",
+        "name": "HSM Templates",
       },
     ]
   }

--- a/src/components/flow/actions/startsession/__snapshots__/StartSessionForm.test.tsx.snap
+++ b/src/components/flow/actions/startsession/__snapshots__/StartSessionForm.test.tsx.snap
@@ -7,8 +7,11 @@ exports[`StartSessionForm render should render 1`] = `
       class="dialog"
     >
       <div
-        class="header start_session"
+        class="header clickable start_session"
       >
+        <div
+          class="header_overlay"
+        />
         <div
           class="title_container"
         >
@@ -33,6 +36,14 @@ exports[`StartSessionForm render should render 1`] = `
             >
               <div>
                 Advanced
+              </div>
+            </div>
+            <div
+              class="tab active"
+              style="display: flex;"
+            >
+              <div>
+                Home
               </div>
             </div>
           </div>

--- a/src/components/flow/routers/classify/__snapshots__/ClassifyRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/classify/__snapshots__/ClassifyRouterForm.test.tsx.snap
@@ -8,8 +8,11 @@ exports[`ClassifyRouterForm defaults to correct result name: initial result name
       class="dialog"
     >
       <div
-        class="header split_by_intent"
+        class="header clickable split_by_intent"
       >
+        <div
+          class="header_overlay"
+        />
         <div
           class="title_container"
         >
@@ -39,6 +42,14 @@ exports[`ClassifyRouterForm defaults to correct result name: initial result name
                 name="check"
                 style="margin-left: 8px;"
               />
+            </div>
+            <div
+              class="tab active"
+              style="display: flex;"
+            >
+              <div>
+                Home
+              </div>
             </div>
           </div>
         </div>
@@ -301,8 +312,11 @@ exports[`ClassifyRouterForm should render: default render 1`] = `
       class="dialog"
     >
       <div
-        class="header split_by_intent"
+        class="header clickable split_by_intent"
       >
+        <div
+          class="header_overlay"
+        />
         <div
           class="title_container"
         >
@@ -332,6 +346,14 @@ exports[`ClassifyRouterForm should render: default render 1`] = `
                 name="check"
                 style="margin-left: 8px;"
               />
+            </div>
+            <div
+              class="tab active"
+              style="display: flex;"
+            >
+              <div>
+                Home
+              </div>
             </div>
           </div>
         </div>
@@ -596,8 +618,11 @@ exports[`ClassifyRouterForm updates the result name: updated result name 1`] = `
       class="dialog"
     >
       <div
-        class="header split_by_intent"
+        class="header clickable split_by_intent"
       >
+        <div
+          class="header_overlay"
+        />
         <div
           class="title_container"
         >
@@ -627,6 +652,14 @@ exports[`ClassifyRouterForm updates the result name: updated result name 1`] = `
                 name="check"
                 style="margin-left: 8px;"
               />
+            </div>
+            <div
+              class="tab active"
+              style="display: flex;"
+            >
+              <div>
+                Home
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/flow/routers/dial/__snapshots__/DialRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/dial/__snapshots__/DialRouterForm.test.tsx.snap
@@ -7,8 +7,11 @@ exports[`DialRouterForm should render 1`] = `
       class="dialog"
     >
       <div
-        class="header wait_for_dial"
+        class="header clickable wait_for_dial"
       >
+        <div
+          class="header_overlay"
+        />
         <div
           class="title_container"
         >
@@ -33,6 +36,14 @@ exports[`DialRouterForm should render 1`] = `
             >
               <div>
                 Advanced
+              </div>
+            </div>
+            <div
+              class="tab active"
+              style="display: flex;"
+            >
+              <div>
+                Home
               </div>
             </div>
           </div>

--- a/src/components/flow/routers/subflow/__snapshots__/SubflowRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/subflow/__snapshots__/SubflowRouterForm.test.tsx.snap
@@ -119,6 +119,14 @@ exports[`SubflowRouterForm should init parameter tab 1`] = `
                 Parameters
               </div>
             </div>
+            <div
+              class="tab "
+              style="display: flex;"
+            >
+              <div>
+                Home
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/flow/routers/webhook/__snapshots__/WebhookRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/webhook/__snapshots__/WebhookRouterForm.test.tsx.snap
@@ -358,8 +358,11 @@ exports[`WebhookRouterForm updates should save changes 1`] = `
       class="dialog"
     >
       <div
-        class="header call_webhook"
+        class="header clickable call_webhook"
       >
+        <div
+          class="header_overlay"
+        />
         <div
           class="title_container"
         >
@@ -397,6 +400,14 @@ exports[`WebhookRouterForm updates should save changes 1`] = `
                 name="check"
                 style="margin-left: 8px;"
               />
+            </div>
+            <div
+              class="tab active"
+              style="display: flex;"
+            >
+              <div>
+                Home
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
resolves https://github.com/glific/glific-frontend/issues/3376 
and 
resolves https://github.com/glific/glific-frontend/issues/3377


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **New Features**
  * Added a "Home" tab to dialogs, displaying the main content alongside other tabs.
* **Improvements**
  * Renamed the "WhatsApp" tab to "HSM Templates" in relevant forms for clearer labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->