### PR TITLE
Changed Default option from has_only_word to has_only_the_phrase

### DIFF
--- a/src/components/flow/actions/sendinteractivemsg/helpers.tsx
+++ b/src/components/flow/actions/sendinteractivemsg/helpers.tsx
@@ -174,7 +174,7 @@ export const stateToRouter = (
       categoryName: `${option.charAt(0).toUpperCase()}${option.slice(1)}`,
       kase: {
         arguments: [option],
-        type: Operators.has_any_word,
+        type: Operators.has_only_phrase,
         uuid,
         category_uuid: null
       },


### PR DESCRIPTION
resolves https://github.com/glific/glific-frontend/issues/3374

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the logic for matching options in interactive messages to use a more precise phrase-matching method. This may improve how user responses are interpreted in certain scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->