### PR TITLE
Made rule translation the default tab and added category translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@glific/flow-editor",
   "license": "AGPL-3.0",
   "repository": "git://github.com/glific/floweditor.git",
-  "version": "1.26.3-29",
+  "version": "1.26.3-30",
   "description": "'Standalone flow editing tool designed for use within the Glific suite of messaging tools'",
   "browser": "umd/flow-editor.min.js",
   "unpkg": "umd/flow-editor.min.js",

--- a/src/components/dialog/Dialog.tsx
+++ b/src/components/dialog/Dialog.tsx
@@ -42,10 +42,12 @@ export interface DialogProps {
   tabs?: Tab[];
   className?: string;
   defaultTab?: number;
+  showHomeTab?: boolean;
 }
 
 export interface DialogState {
   activeTab: number;
+  showHomeTab?: boolean;
 }
 
 /**
@@ -59,8 +61,14 @@ export default class Dialog extends React.Component<DialogProps, DialogState> {
     super(props);
 
     if (this.props.tabs && this.props.tabs.length > 0) {
+      const activeTab =
+        this.props.defaultTab !== null && this.props.defaultTab !== undefined
+          ? this.props.defaultTab
+          : this.props.tabs.length;
+
       this.state = {
-        activeTab: this.props.tabs.length
+        activeTab: activeTab,
+        showHomeTab: this.props.showHomeTab !== false
       };
     } else {
       this.state = {
@@ -173,8 +181,9 @@ export default class Dialog extends React.Component<DialogProps, DialogState> {
       name: 'Home',
       body: <>{this.props.children}</>
     };
+
     let allTabs = [...(this.props.tabs || [])];
-    if (this.props.tabs && this.props.tabs.length > 0) {
+    if (this.props.tabs && this.props.tabs.length > 0 && this.state.showHomeTab) {
       allTabs = [...allTabs, homeTab];
     }
 
@@ -247,7 +256,8 @@ export default class Dialog extends React.Component<DialogProps, DialogState> {
         </div>
 
         <div className={this.props.noPadding ? '' : styles.content}>
-          {this.state.activeTab > -1 ? allTabs[this.state.activeTab].body : homeTab.body}
+          {this.props.defaultTab ||
+            (this.state.activeTab > -1 ? allTabs[this.state.activeTab].body : homeTab.body)}
         </div>
 
         <div className={styles.footer}>

--- a/src/components/dialog/Dialog.tsx
+++ b/src/components/dialog/Dialog.tsx
@@ -42,12 +42,11 @@ export interface DialogProps {
   tabs?: Tab[];
   className?: string;
   defaultTab?: number;
-  showHomeTab?: boolean;
+  homeTabName?: string;
 }
 
 export interface DialogState {
   activeTab: number;
-  showHomeTab?: boolean;
 }
 
 /**
@@ -61,14 +60,8 @@ export default class Dialog extends React.Component<DialogProps, DialogState> {
     super(props);
 
     if (this.props.tabs && this.props.tabs.length > 0) {
-      const activeTab =
-        this.props.defaultTab !== null && this.props.defaultTab !== undefined
-          ? this.props.defaultTab
-          : this.props.tabs.length;
-
       this.state = {
-        activeTab: activeTab,
-        showHomeTab: this.props.showHomeTab !== false
+        activeTab: this.props.tabs.length
       };
     } else {
       this.state = {
@@ -178,12 +171,11 @@ export default class Dialog extends React.Component<DialogProps, DialogState> {
 
   public render(): JSX.Element {
     const homeTab: Tab = {
-      name: 'Home',
+      name: this.props.homeTabName || 'Home',
       body: <>{this.props.children}</>
     };
-
     let allTabs = [...(this.props.tabs || [])];
-    if (this.props.tabs && this.props.tabs.length > 0 && this.state.showHomeTab) {
+    if (this.props.tabs && this.props.tabs.length > 0) {
       allTabs = [...allTabs, homeTab];
     }
 
@@ -256,8 +248,7 @@ export default class Dialog extends React.Component<DialogProps, DialogState> {
         </div>
 
         <div className={this.props.noPadding ? '' : styles.content}>
-          {this.props.defaultTab ||
-            (this.state.activeTab > -1 ? allTabs[this.state.activeTab].body : homeTab.body)}
+          {this.state.activeTab > -1 ? allTabs[this.state.activeTab].body : homeTab.body}
         </div>
 
         <div className={styles.footer}>

--- a/src/components/flow/routers/localization/RouterLocalizationForm.tsx
+++ b/src/components/flow/routers/localization/RouterLocalizationForm.tsx
@@ -247,6 +247,7 @@ export default class RouterLocalizationForm extends React.Component<
         buttons={this.getButtons()}
         tabs={tabs}
         defaultTab={defaultTab}
+        showHomeTab={false}
       >
         <p data-spec="instructions">
           When category names are referenced later in the flow, the appropriate language for the

--- a/src/components/flow/routers/localization/RouterLocalizationForm.tsx
+++ b/src/components/flow/routers/localization/RouterLocalizationForm.tsx
@@ -217,22 +217,22 @@ export default class RouterLocalizationForm extends React.Component<
 
     if (hasCasesWithArguments) {
       tabs.push({
-        name: 'Rule Translations',
+        name: 'Category Translations',
         body: (
           <>
             <p data-spec="instructions">
-              Sometimes languages need special rules to route things properly. If a translation is
-              not provided, the original rule will be used.
+              When category names are referenced later in the flow, the appropriate language for the
+              category will be used. If no translation is provided, the original text will be used.
             </p>
             <div
               className={
                 styles.translating_list_container +
                 ' ' +
-                (this.state.cases.length > 5 ? styles.scrolling : '')
+                (this.state.categories.length > 5 ? styles.scrolling : '')
               }
               tabIndex={0}
             >
-              <div className={styles.translating_item_list}>{this.renderCases()}</div>
+              <div className={styles.translating_item_list}>{this.renderCategories()}</div>
             </div>
           </>
         )
@@ -246,23 +246,23 @@ export default class RouterLocalizationForm extends React.Component<
         headerClass={typeConfig.type}
         buttons={this.getButtons()}
         tabs={tabs}
-        defaultTab={defaultTab}
-        showHomeTab={false}
+        homeTabName="Rule Translations"
       >
         <p data-spec="instructions">
-          When category names are referenced later in the flow, the appropriate language for the
-          category will be used. If no translation is provided, the original text will be used.
+          Sometimes languages need special rules to route things properly. If a translation is not
+          provided, the original rule will be used.
         </p>
         <div
           className={
             styles.translating_list_container +
             ' ' +
-            (this.state.categories.length > 5 ? styles.scrolling : '')
+            (this.state.cases.length > 5 ? styles.scrolling : '')
           }
           tabIndex={0}
         >
-          <div className={styles.translating_item_list}>{this.renderCategories()}</div>
+          <div className={styles.translating_item_list}>{this.renderCases()}</div>
         </div>
+
         {renderIssues(this.props)}
       </Dialog>
     );

--- a/src/components/flow/routers/localization/RouterLocalizationForm.tsx
+++ b/src/components/flow/routers/localization/RouterLocalizationForm.tsx
@@ -204,50 +204,8 @@ export default class RouterLocalizationForm extends React.Component<
 
     const tabs: Tab[] = [];
 
-    const hasCasesWithArguments = !!this.state.cases.find((kase: Case) => {
-      const orginalCase = getOriginalCase(this.props.nodeSettings, kase.uuid) as Case;
-      return (
-        orginalCase.arguments &&
-        orginalCase.arguments.length > 0 &&
-        orginalCase.type !== Operators.has_number_between
-      );
-    });
-
-    let defaultTab;
-
-    if (hasCasesWithArguments) {
-      tabs.push({
-        name: 'Category Translations',
-        body: (
-          <>
-            <p data-spec="instructions">
-              When category names are referenced later in the flow, the appropriate language for the
-              category will be used. If no translation is provided, the original text will be used.
-            </p>
-            <div
-              className={
-                styles.translating_list_container +
-                ' ' +
-                (this.state.categories.length > 5 ? styles.scrolling : '')
-              }
-              tabIndex={0}
-            >
-              <div className={styles.translating_item_list}>{this.renderCategories()}</div>
-            </div>
-          </>
-        )
-      });
-      defaultTab = 0;
-    }
-
-    const categories = (
-      <Dialog
-        title={`${this.props.language.name} Category Names`}
-        headerClass={typeConfig.type}
-        buttons={this.getButtons()}
-        tabs={tabs}
-        homeTabName="Rule Translations"
-      >
+    const ruleTranslationsTab = (
+      <>
         <p data-spec="instructions">
           Sometimes languages need special rules to route things properly. If a translation is not
           provided, the original rule will be used.
@@ -262,7 +220,55 @@ export default class RouterLocalizationForm extends React.Component<
         >
           <div className={styles.translating_item_list}>{this.renderCases()}</div>
         </div>
+      </>
+    );
 
+    const categoryTranslationsTab = (
+      <>
+        <p data-spec="instructions">
+          When category names are referenced later in the flow, the appropriate language for the
+          category will be used. If no translation is provided, the original text will be used.
+        </p>
+        <div
+          className={
+            styles.translating_list_container +
+            ' ' +
+            (this.state.categories.length > 5 ? styles.scrolling : '')
+          }
+          tabIndex={0}
+        >
+          <div className={styles.translating_item_list}>{this.renderCategories()}</div>
+        </div>
+      </>
+    );
+
+    const hasCasesWithArguments = !!this.state.cases.find((kase: Case) => {
+      const orginalCase = getOriginalCase(this.props.nodeSettings, kase.uuid) as Case;
+      return (
+        orginalCase.arguments &&
+        orginalCase.arguments.length > 0 &&
+        orginalCase.type !== Operators.has_number_between
+      );
+    });
+
+    if (hasCasesWithArguments) {
+      tabs.push({
+        name: 'Category Translations',
+        body: categoryTranslationsTab
+      });
+    }
+
+    const defaultTabBody = hasCasesWithArguments ? ruleTranslationsTab : categoryTranslationsTab;
+
+    const categories = (
+      <Dialog
+        title={`${this.props.language.name} Category Names`}
+        headerClass={typeConfig.type}
+        buttons={this.getButtons()}
+        tabs={tabs}
+        homeTabName="Rule Translations"
+      >
+        {defaultTabBody}
         {renderIssues(this.props)}
       </Dialog>
     );

--- a/src/components/flow/routers/localization/__snapshots__/RouterLocalizationForm.test.ts.snap
+++ b/src/components/flow/routers/localization/__snapshots__/RouterLocalizationForm.test.ts.snap
@@ -14,9 +14,8 @@ exports[`RouterLocalizationForm initializes 1`] = `
       },
     }
   }
-  defaultTab={0}
   headerClass="wait_for_response"
-  showHomeTab={false}
+  homeTabName="Rule Translations"
   tabs={
     Array [
       Object {
@@ -24,7 +23,7 @@ exports[`RouterLocalizationForm initializes 1`] = `
           <p
             data-spec="instructions"
           >
-            Sometimes languages need special rules to route things properly. If a translation is not provided, the original rule will be used.
+            When category names are referenced later in the flow, the appropriate language for the category will be used. If no translation is provided, the original text will be used.
           </p>
           <div
             className="translating_list_container "
@@ -34,18 +33,11 @@ exports[`RouterLocalizationForm initializes 1`] = `
               className="translating_item_list"
             >
               <div
-                className="translating_operator_container"
-                data-spec="operator-field"
+                className="translating_category"
               >
                 <div
-                  className="translating_operator"
-                  data-spec="verbose-name"
-                >
-                  has any of the words
-                </div>
-                <div
                   className="translating_from"
-                  data-spec="argument-to-translate"
+                  data-spec="category-name"
                 >
                   Red
                 </div>
@@ -53,13 +45,13 @@ exports[`RouterLocalizationForm initializes 1`] = `
                   className="translating_to"
                 >
                   <TextInputElement
-                    data-spec="localize-case"
+                    data-spec="localize-category"
                     entry={
                       Object {
-                        "value": "rojo, r",
+                        "value": "",
                       }
                     }
-                    name="061fc171-8b79-4636-b892-bd0ea5aa9b42"
+                    name=""
                     onChange={[Function]}
                     placeholder="Spanish Translation"
                     showLabel={false}
@@ -67,18 +59,11 @@ exports[`RouterLocalizationForm initializes 1`] = `
                 </div>
               </div>
               <div
-                className="translating_operator_container"
-                data-spec="operator-field"
+                className="translating_category"
               >
                 <div
-                  className="translating_operator"
-                  data-spec="verbose-name"
-                >
-                  has any of the words
-                </div>
-                <div
                   className="translating_from"
-                  data-spec="argument-to-translate"
+                  data-spec="category-name"
                 >
                   Blue
                 </div>
@@ -86,13 +71,39 @@ exports[`RouterLocalizationForm initializes 1`] = `
                   className="translating_to"
                 >
                   <TextInputElement
-                    data-spec="localize-case"
+                    data-spec="localize-category"
                     entry={
                       Object {
                         "value": "",
                       }
                     }
-                    name="763e4844-3e1b-407a-a1b5-5fdfcd308b41"
+                    name=""
+                    onChange={[Function]}
+                    placeholder="Spanish Translation"
+                    showLabel={false}
+                  />
+                </div>
+              </div>
+              <div
+                className="translating_category"
+              >
+                <div
+                  className="translating_from"
+                  data-spec="category-name"
+                >
+                  Other
+                </div>
+                <div
+                  className="translating_to"
+                >
+                  <TextInputElement
+                    data-spec="localize-category"
+                    entry={
+                      Object {
+                        "value": "Otro",
+                      }
+                    }
+                    name="Otro"
                     onChange={[Function]}
                     placeholder="Spanish Translation"
                     showLabel={false}
@@ -102,7 +113,7 @@ exports[`RouterLocalizationForm initializes 1`] = `
             </div>
           </div>
         </React.Fragment>,
-        "name": "Rule Translations",
+        "name": "Category Translations",
       },
     ]
   }
@@ -111,7 +122,7 @@ exports[`RouterLocalizationForm initializes 1`] = `
   <p
     data-spec="instructions"
   >
-    When category names are referenced later in the flow, the appropriate language for the category will be used. If no translation is provided, the original text will be used.
+    Sometimes languages need special rules to route things properly. If a translation is not provided, the original rule will be used.
   </p>
   <div
     className="translating_list_container "
@@ -121,12 +132,19 @@ exports[`RouterLocalizationForm initializes 1`] = `
       className="translating_item_list"
     >
       <div
-        className="translating_category"
-        key="1e47a1e1-3c67-4df5-adf1-da542c789adb"
+        className="translating_operator_container"
+        data-spec="operator-field"
+        key="translate_061fc171-8b79-4636-b892-bd0ea5aa9b42"
       >
         <div
+          className="translating_operator"
+          data-spec="verbose-name"
+        >
+          has any of the words
+        </div>
+        <div
           className="translating_from"
-          data-spec="category-name"
+          data-spec="argument-to-translate"
         >
           Red
         </div>
@@ -134,13 +152,13 @@ exports[`RouterLocalizationForm initializes 1`] = `
           className="translating_to"
         >
           <TextInputElement
-            data-spec="localize-category"
+            data-spec="localize-case"
             entry={
               Object {
-                "value": "",
+                "value": "rojo, r",
               }
             }
-            name=""
+            name="061fc171-8b79-4636-b892-bd0ea5aa9b42"
             onChange={[Function]}
             placeholder="Spanish Translation"
             showLabel={false}
@@ -148,12 +166,19 @@ exports[`RouterLocalizationForm initializes 1`] = `
         </div>
       </div>
       <div
-        className="translating_category"
-        key="2dc85899-0577-4f1b-a620-f12094e34b5e"
+        className="translating_operator_container"
+        data-spec="operator-field"
+        key="translate_763e4844-3e1b-407a-a1b5-5fdfcd308b41"
       >
         <div
+          className="translating_operator"
+          data-spec="verbose-name"
+        >
+          has any of the words
+        </div>
+        <div
           className="translating_from"
-          data-spec="category-name"
+          data-spec="argument-to-translate"
         >
           Blue
         </div>
@@ -161,40 +186,13 @@ exports[`RouterLocalizationForm initializes 1`] = `
           className="translating_to"
         >
           <TextInputElement
-            data-spec="localize-category"
+            data-spec="localize-case"
             entry={
               Object {
                 "value": "",
               }
             }
-            name=""
-            onChange={[Function]}
-            placeholder="Spanish Translation"
-            showLabel={false}
-          />
-        </div>
-      </div>
-      <div
-        className="translating_category"
-        key="70ac6ea6-803a-4c33-81c7-dc26803c313f"
-      >
-        <div
-          className="translating_from"
-          data-spec="category-name"
-        >
-          Other
-        </div>
-        <div
-          className="translating_to"
-        >
-          <TextInputElement
-            data-spec="localize-category"
-            entry={
-              Object {
-                "value": "Otro",
-              }
-            }
-            name="Otro"
+            name="763e4844-3e1b-407a-a1b5-5fdfcd308b41"
             onChange={[Function]}
             placeholder="Spanish Translation"
             showLabel={false}
@@ -220,9 +218,8 @@ exports[`RouterLocalizationForm should render 1`] = `
       },
     }
   }
-  defaultTab={0}
   headerClass="wait_for_response"
-  showHomeTab={false}
+  homeTabName="Rule Translations"
   tabs={
     Array [
       Object {
@@ -230,7 +227,7 @@ exports[`RouterLocalizationForm should render 1`] = `
           <p
             data-spec="instructions"
           >
-            Sometimes languages need special rules to route things properly. If a translation is not provided, the original rule will be used.
+            When category names are referenced later in the flow, the appropriate language for the category will be used. If no translation is provided, the original text will be used.
           </p>
           <div
             className="translating_list_container "
@@ -240,18 +237,11 @@ exports[`RouterLocalizationForm should render 1`] = `
               className="translating_item_list"
             >
               <div
-                className="translating_operator_container"
-                data-spec="operator-field"
+                className="translating_category"
               >
                 <div
-                  className="translating_operator"
-                  data-spec="verbose-name"
-                >
-                  has any of the words
-                </div>
-                <div
                   className="translating_from"
-                  data-spec="argument-to-translate"
+                  data-spec="category-name"
                 >
                   Red
                 </div>
@@ -259,13 +249,13 @@ exports[`RouterLocalizationForm should render 1`] = `
                   className="translating_to"
                 >
                   <TextInputElement
-                    data-spec="localize-case"
+                    data-spec="localize-category"
                     entry={
                       Object {
-                        "value": "rojo, r",
+                        "value": "",
                       }
                     }
-                    name="061fc171-8b79-4636-b892-bd0ea5aa9b42"
+                    name=""
                     onChange={[Function]}
                     placeholder="Spanish Translation"
                     showLabel={false}
@@ -273,18 +263,11 @@ exports[`RouterLocalizationForm should render 1`] = `
                 </div>
               </div>
               <div
-                className="translating_operator_container"
-                data-spec="operator-field"
+                className="translating_category"
               >
                 <div
-                  className="translating_operator"
-                  data-spec="verbose-name"
-                >
-                  has any of the words
-                </div>
-                <div
                   className="translating_from"
-                  data-spec="argument-to-translate"
+                  data-spec="category-name"
                 >
                   Blue
                 </div>
@@ -292,13 +275,39 @@ exports[`RouterLocalizationForm should render 1`] = `
                   className="translating_to"
                 >
                   <TextInputElement
-                    data-spec="localize-case"
+                    data-spec="localize-category"
                     entry={
                       Object {
                         "value": "",
                       }
                     }
-                    name="763e4844-3e1b-407a-a1b5-5fdfcd308b41"
+                    name=""
+                    onChange={[Function]}
+                    placeholder="Spanish Translation"
+                    showLabel={false}
+                  />
+                </div>
+              </div>
+              <div
+                className="translating_category"
+              >
+                <div
+                  className="translating_from"
+                  data-spec="category-name"
+                >
+                  Other
+                </div>
+                <div
+                  className="translating_to"
+                >
+                  <TextInputElement
+                    data-spec="localize-category"
+                    entry={
+                      Object {
+                        "value": "Otro",
+                      }
+                    }
+                    name="Otro"
                     onChange={[Function]}
                     placeholder="Spanish Translation"
                     showLabel={false}
@@ -308,7 +317,7 @@ exports[`RouterLocalizationForm should render 1`] = `
             </div>
           </div>
         </React.Fragment>,
-        "name": "Rule Translations",
+        "name": "Category Translations",
       },
     ]
   }
@@ -317,7 +326,7 @@ exports[`RouterLocalizationForm should render 1`] = `
   <p
     data-spec="instructions"
   >
-    When category names are referenced later in the flow, the appropriate language for the category will be used. If no translation is provided, the original text will be used.
+    Sometimes languages need special rules to route things properly. If a translation is not provided, the original rule will be used.
   </p>
   <div
     className="translating_list_container "
@@ -327,12 +336,19 @@ exports[`RouterLocalizationForm should render 1`] = `
       className="translating_item_list"
     >
       <div
-        className="translating_category"
-        key="1e47a1e1-3c67-4df5-adf1-da542c789adb"
+        className="translating_operator_container"
+        data-spec="operator-field"
+        key="translate_061fc171-8b79-4636-b892-bd0ea5aa9b42"
       >
         <div
+          className="translating_operator"
+          data-spec="verbose-name"
+        >
+          has any of the words
+        </div>
+        <div
           className="translating_from"
-          data-spec="category-name"
+          data-spec="argument-to-translate"
         >
           Red
         </div>
@@ -340,13 +356,13 @@ exports[`RouterLocalizationForm should render 1`] = `
           className="translating_to"
         >
           <TextInputElement
-            data-spec="localize-category"
+            data-spec="localize-case"
             entry={
               Object {
-                "value": "",
+                "value": "rojo, r",
               }
             }
-            name=""
+            name="061fc171-8b79-4636-b892-bd0ea5aa9b42"
             onChange={[Function]}
             placeholder="Spanish Translation"
             showLabel={false}
@@ -354,12 +370,19 @@ exports[`RouterLocalizationForm should render 1`] = `
         </div>
       </div>
       <div
-        className="translating_category"
-        key="2dc85899-0577-4f1b-a620-f12094e34b5e"
+        className="translating_operator_container"
+        data-spec="operator-field"
+        key="translate_763e4844-3e1b-407a-a1b5-5fdfcd308b41"
       >
         <div
+          className="translating_operator"
+          data-spec="verbose-name"
+        >
+          has any of the words
+        </div>
+        <div
           className="translating_from"
-          data-spec="category-name"
+          data-spec="argument-to-translate"
         >
           Blue
         </div>
@@ -367,40 +390,13 @@ exports[`RouterLocalizationForm should render 1`] = `
           className="translating_to"
         >
           <TextInputElement
-            data-spec="localize-category"
+            data-spec="localize-case"
             entry={
               Object {
                 "value": "",
               }
             }
-            name=""
-            onChange={[Function]}
-            placeholder="Spanish Translation"
-            showLabel={false}
-          />
-        </div>
-      </div>
-      <div
-        className="translating_category"
-        key="70ac6ea6-803a-4c33-81c7-dc26803c313f"
-      >
-        <div
-          className="translating_from"
-          data-spec="category-name"
-        >
-          Other
-        </div>
-        <div
-          className="translating_to"
-        >
-          <TextInputElement
-            data-spec="localize-category"
-            entry={
-              Object {
-                "value": "Otro",
-              }
-            }
-            name="Otro"
+            name="763e4844-3e1b-407a-a1b5-5fdfcd308b41"
             onChange={[Function]}
             placeholder="Spanish Translation"
             showLabel={false}

--- a/src/components/flow/routers/localization/__snapshots__/RouterLocalizationForm.test.ts.snap
+++ b/src/components/flow/routers/localization/__snapshots__/RouterLocalizationForm.test.ts.snap
@@ -16,6 +16,7 @@ exports[`RouterLocalizationForm initializes 1`] = `
   }
   defaultTab={0}
   headerClass="wait_for_response"
+  showHomeTab={false}
   tabs={
     Array [
       Object {
@@ -221,6 +222,7 @@ exports[`RouterLocalizationForm should render 1`] = `
   }
   defaultTab={0}
   headerClass="wait_for_response"
+  showHomeTab={false}
   tabs={
     Array [
       Object {

--- a/src/components/flow/routers/subflow/__snapshots__/SubflowRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/subflow/__snapshots__/SubflowRouterForm.test.tsx.snap
@@ -119,6 +119,14 @@ exports[`SubflowRouterForm should init parameter tab 1`] = `
                 Parameters
               </div>
             </div>
+            <div
+              class="tab "
+              style="display: flex;"
+            >
+              <div>
+                Home
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/flow/routers/subflow/__snapshots__/SubflowRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/subflow/__snapshots__/SubflowRouterForm.test.tsx.snap
@@ -119,14 +119,6 @@ exports[`SubflowRouterForm should init parameter tab 1`] = `
                 Parameters
               </div>
             </div>
-            <div
-              class="tab "
-              style="display: flex;"
-            >
-              <div>
-                Home
-              </div>
-            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
target issue is https://github.com/glific/glific-frontend/issues/3425

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dialogs support a configurable Home tab label and only add the Home tab when user tabs exist.
  * Translation UI now shows a category-focused tab and uses rule translations as the default pane when applicable.

* **Bug Fixes**
  * Active-tab initialization refined so Home becomes the default only when appropriate; Home is hidden when no user tabs exist.

* **Chores**
  * Package version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->