### PR TITLE
Show default language label instead of generic “Default"

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@glific/flow-editor",
   "license": "AGPL-3.0",
   "repository": "git://github.com/glific/floweditor.git",
-  "version": "1.43.0-1",
+  "version": "1.43.0-2",
   "description": "'Standalone flow editing tool designed for use within the Glific suite of messaging tools'",
   "browser": "umd/flow-editor.min.js",
   "unpkg": "umd/flow-editor.min.js",

--- a/src/components/languageselector/LanguageSelector.module.scss
+++ b/src/components/languageselector/LanguageSelector.module.scss
@@ -37,6 +37,7 @@
     text-decoration: none;
     color: $gray;
     cursor: default;
+    font-weight: 500;
   }
 }
 

--- a/src/components/languageselector/LanguageSelector.tsx
+++ b/src/components/languageselector/LanguageSelector.tsx
@@ -52,6 +52,7 @@ export class LanguageSelector extends React.Component<LanguageSelectorProps> {
 
     const languages = Object.keys(this.props.languages.items)
       .map((iso: string) => this.props.languages.items[iso])
+      .filter((lang: Asset) => !lang.content?.default)
       .sort(this.handleLanguageSort);
 
     if (languages.length === 1) {
@@ -101,7 +102,4 @@ const mapDispatchToProps = (dispatch: DispatchWithState) =>
     dispatch
   );
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(LanguageSelector);
+export default connect(mapStateToProps, mapDispatchToProps)(LanguageSelector);

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -371,10 +371,18 @@ export const loadFlowDefinition = (details: FlowDetails, assetStore: AssetStore)
     language = assetStore.languages.items[definition.language];
   }
 
+  const defaultLanguage = Object.values(assetStore.languages.items).find(
+    (lang: any) => lang.content.default
+  );
+
   if (!language) {
-    language = DEFAULT_LANGUAGE;
-    dispatch(mergeEditorState({ language: DEFAULT_LANGUAGE }));
-    mergeAssetMaps(assetStore.languages.items, { base: DEFAULT_LANGUAGE });
+    const defaultTab = {
+      ...DEFAULT_LANGUAGE,
+      name: defaultLanguage ? `Default (${defaultLanguage.name})` : DEFAULT_LANGUAGE.name
+    };
+    language = defaultTab;
+    dispatch(mergeEditorState({ language: defaultTab }));
+    mergeAssetMaps(assetStore.languages.items, { base: defaultTab });
   }
 
   if (details.issues) {


### PR DESCRIPTION
target issue is https://github.com/glific/glific-frontend/issues/3339
We worked on this earlier, but made a few more changes after product managers’ [feedback](https://docs.google.com/spreadsheets/d/1UmILNeEmXkQUpRwwzZQhfI62hxSrqfUTnt1Ghux3Av0/edit?gid=0#gid=0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects and displays a more descriptive "Default (<Language>)" when no language is set in the editor.
  * Hides default language entries from the language selector to reduce clutter.

* **Style**
  * Increased font weight for the active language link for improved visibility.

* **Chores**
  * Package version bumped to 1.43.0-2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->