### PR TITLE
add fields to store on create

### DIFF
--- a/src/store/flowContext.ts
+++ b/src/store/flowContext.ts
@@ -210,10 +210,14 @@ export const updateContactFields = (contactFields: ContactFields): UpdateContact
   }
 });
 
-export const updateAssets = (assets: AssetStore): UpdateAssetsAction => {
+export const updateAssets = (
+  assets: AssetStore,
+  assetName: string = 'results'
+): UpdateAssetsAction => {
   const store: TembaStore = document.querySelector('temba-store');
+
   if (store) {
-    store.setKeyedAssets('results', Object.keys(assets['results'].items));
+    store.setKeyedAssets(assetName, Object.keys(assets[assetName].items));
   }
 
   return {

--- a/src/store/helpers.ts
+++ b/src/store/helpers.ts
@@ -498,7 +498,7 @@ export const generateResultQuery = (resultName: string) => `@run.results.${snaki
 export const assetListToMap = (assets: Asset[]): AssetMap => {
   const assetMap: any = {};
   for (const asset of assets) {
-    assetMap[asset.id] = asset;
+    assetMap[asset.id || asset.name] = asset;
   }
   return assetMap;
 };

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -812,9 +812,17 @@ export const onUpdateAction = (
       node: {
         uuid: createUUID(),
         actions: [action],
-        exits: [{ uuid: createUUID(), destination_uuid: null }]
+        exits: [
+          {
+            uuid: createUUID(),
+            destination_uuid: null
+          }
+        ]
       },
-      ui: { position: originalNode.ui.position, type: Types.execute_actions },
+      ui: {
+        position: originalNode.ui.position,
+        type: Types.execute_actions
+      },
       inboundConnections: originalNode.inboundConnections
     };
     updatedNodes = mutators.mergeNode(nodes, newNode);
@@ -845,17 +853,19 @@ export const onUpdateAction = (
     dispatch(updateAssets(updatedAssets));
   }
 
+  // Add contact field to our store.
   if (action && action.type === Types.set_contact_field) {
     const { field }: any = action as SetContactField;
 
     updatedAssets = mutators.addAssets('fields', assetStore, [field]);
 
     dispatch(updateAssets(updatedAssets, 'fields'));
-    dispatch(updateContactFields({ ...contactFields, [field.key]: field.name }));
-  }
-
-  // Add contact field to our store.
-  if (action.type === Types.set_contact_field) {
+    dispatch(
+      updateContactFields({
+        ...contactFields,
+        [field.key]: field.name
+      })
+    );
   }
 
   markDirty(0);

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -801,6 +801,11 @@ export const onUpdateAction = (
       actionUUID: action.uuid
     });
   }
+  if (action && action.type === Types.set_contact_field) {
+    const value: any = action;
+    updatedAssets = mutators.addAssets('fields', assetStore, [value.field]);
+    dispatch(updateAssets(updatedAssets, 'fields'));
+  }
 
   let updatedNodes = nodes;
   const creatingNewNode = !!(originalNode !== null && originalNode.ghost);

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -801,11 +801,6 @@ export const onUpdateAction = (
       actionUUID: action.uuid
     });
   }
-  if (action && action.type === Types.set_contact_field) {
-    const value: any = action;
-    updatedAssets = mutators.addAssets('fields', assetStore, [value.field]);
-    dispatch(updateAssets(updatedAssets, 'fields'));
-  }
 
   let updatedNodes = nodes;
   const creatingNewNode = !!(originalNode !== null && originalNode.ghost);
@@ -850,10 +845,17 @@ export const onUpdateAction = (
     dispatch(updateAssets(updatedAssets));
   }
 
+  if (action && action.type === Types.set_contact_field) {
+    const { field }: any = action as SetContactField;
+
+    updatedAssets = mutators.addAssets('fields', assetStore, [field]);
+
+    dispatch(updateAssets(updatedAssets, 'fields'));
+    dispatch(updateContactFields({ ...contactFields, [field.key]: field.name }));
+  }
+
   // Add contact field to our store.
   if (action.type === Types.set_contact_field) {
-    const { field } = action as SetContactField;
-    dispatch(updateContactFields({ ...contactFields, [field.key]: field.name }));
   }
 
   markDirty(0);

--- a/src/utils/__snapshots__/index.test.tsx.snap
+++ b/src/utils/__snapshots__/index.test.tsx.snap
@@ -17,6 +17,42 @@ LocalizedObject {
   "iso": undefined,
   "language": Object {
     "iso": undefined,
+    "name": "English",
+  },
+  "localized": false,
+  "localizedKeys": Object {},
+  "localizedObject": Object {
+    "text": "Hi there, what is your name?",
+    "type": "send_msg",
+    "uuid": "360a28a1-6741-4f16-9421-f6f313cf753e",
+  },
+  "name": undefined,
+}
+`;
+
+exports[`utils getLocalizations should return a localized object 2`] = `
+LocalizedObject {
+  "iso": undefined,
+  "language": Object {
+    "iso": undefined,
+    "name": "Spanish",
+  },
+  "localized": false,
+  "localizedKeys": Object {},
+  "localizedObject": Object {
+    "text": "Hi there, what is your name?",
+    "type": "send_msg",
+    "uuid": "360a28a1-6741-4f16-9421-f6f313cf753e",
+  },
+  "name": undefined,
+}
+`;
+
+exports[`utils getLocalizations should return a localized object 3`] = `
+LocalizedObject {
+  "iso": undefined,
+  "language": Object {
+    "iso": undefined,
     "name": "French",
   },
   "localized": false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Support updating different asset groups (not just results) for more flexible data updates.
  - Contact field edits now add/update the related asset group and contact-field mapping immediately.

- Bug Fixes
  - Assets without IDs now fall back to names to prevent missing or duplicate entries.
  - Improved asset mapping to ensure lists display correct items after updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->