### PR TITLE
Add list of webhook functions as dropdown in call a webhook node

### DIFF
--- a/src/components/flow/routers/webhook/WebhookRouterForm.tsx
+++ b/src/components/flow/routers/webhook/WebhookRouterForm.tsx
@@ -89,7 +89,7 @@ export default class WebhookRouterForm extends React.Component<
 
     if (this.state.method.value.value === Methods.FUNCTION && this.state.url.value) {
       const functionName = this.state.url.value;
-      const selectedOption = webhookOptions.find(opt => opt.name === functionName);
+      const selectedOption = webhookOptions.find((opt: any) => opt.name === functionName);
 
       this.setState({
         webhookOptions,

--- a/src/components/flow/routers/webhook/WebhookRouterForm.tsx
+++ b/src/components/flow/routers/webhook/WebhookRouterForm.tsx
@@ -50,7 +50,7 @@ export interface WebhookRouterFormState extends FormState {
   body: StringEntry;
   resultName: StringEntry;
   webhookFunction: FormEntry;
-  webhookOptions: any[]; //
+  webhookOptions: any[];
 }
 
 export default class WebhookRouterForm extends React.Component<

--- a/src/components/flow/routers/webhook/WebhookRouterForm.tsx
+++ b/src/components/flow/routers/webhook/WebhookRouterForm.tsx
@@ -76,35 +76,53 @@ export default class WebhookRouterForm extends React.Component<
   }
 
   async componentDidMount() {
-    const endpoint = this.context?.config?.endpoints?.completion;
-    if (endpoint) {
-      const response = await fetch(endpoint);
-      const data = await response.json();
+    const endpoint = this.context.config.endpoints.completion;
+    const response = await fetch(endpoint);
+    const data = await response.json();
 
-      this.setState({ webhookOptions: data.webhook });
-    }
+    const webhookOptions = (data.webhook || []).map((webhook: any) => ({
+      name: webhook.name,
+      body: webhook.body
+    }));
+
+    this.setState({ webhookOptions });
   }
 
   private handleWebhookFunctionChanged(selected: any[]): boolean {
-    const updates: Partial<WebhookRouterFormState> = {
-      webhookFunction: { value: selected }
-    };
+    const selectedArray = !selected ? [] : Array.isArray(selected) ? selected : [selected];
 
-    if (selected && selected.length > 0) {
-      const webhookName = selected[0].name || selected[0].value || selected[0];
-      const webhook = this.state.webhookOptions.find(w => w.name === webhookName);
-
-      updates.url = { value: webhookName };
-
-      if (webhook && webhook.body) {
-        updates.body = { value: webhook.body };
-      }
-    } else {
-      updates.url = { value: '' };
+    if (selectedArray.length === 0) {
+      const updates: Partial<WebhookRouterFormState> = {
+        webhookFunction: { value: null },
+        url: { value: '' },
+        body: { value: '' }
+      };
+      const updated = mergeForm(this.state, updates) as WebhookRouterFormState;
+      this.setState(updated);
+      return updated.valid;
     }
 
-    const updated = mergeForm(this.state, updates);
+    const selectedItem = selectedArray[0];
+    const webhookName =
+      typeof selectedItem === 'string'
+        ? selectedItem
+        : selectedItem?.value ||
+          selectedItem?.name ||
+          selectedItem?.id ||
+          selectedItem?.label ||
+          '';
+
+    const webhook = this.state.webhookOptions.find(w => w.name === webhookName);
+
+    const updates: Partial<WebhookRouterFormState> = {
+      webhookFunction: { value: selectedArray },
+      url: { value: webhookName },
+      body: { value: webhook?.body || '' }
+    };
+
+    const updated = mergeForm(this.state, updates) as WebhookRouterFormState;
     this.setState(updated);
+
     return updated.valid;
   }
 
@@ -136,14 +154,15 @@ export default class WebhookRouterForm extends React.Component<
           (header: HeaderEntry) => header.value.name.toLowerCase() === 'content-type'
         );
 
-        // whenever our method changes, update the default body
-        updates.body = { value: getDefaultBody(newMethod) };
+        // Only set default body for non-FUNCTION methods
+        if (newMethod !== Methods.FUNCTION) {
+          updates.body = { value: getDefaultBody(newMethod) };
+        }
 
         // switching from a GET, add a content-type
         if (oldMethod === Methods.GET && newMethod !== Methods.GET) {
           if (!existingContentTypeHeader) {
             let uuid = createUUID();
-            // if we have an empty header, use that one
             const lastHeader =
               this.state.headers.length > 0
                 ? this.state.headers[this.state.headers.length - 1]
@@ -154,7 +173,6 @@ export default class WebhookRouterForm extends React.Component<
             keys.header = { uuid, name: 'Content-Type', value: 'application/json' };
           }
         } else if (oldMethod !== Methods.GET && newMethod === Methods.GET) {
-          // remove content type if switching to a GET
           if (existingContentTypeHeader) {
             toRemove = [{ headers: [{ value: existingContentTypeHeader.value }] }];
           }
@@ -179,7 +197,13 @@ export default class WebhookRouterForm extends React.Component<
     }
 
     if (keys.hasOwnProperty('body')) {
-      updates.body = validate('POST body', keys.body, [isValidJson()]);
+      // Don't validate JSON for empty body in FUNCTION method
+      const isFunction = this.state.method.value.value === Methods.FUNCTION;
+      if (isFunction && keys.body.trim() === '') {
+        updates.body = { value: keys.body };
+      } else {
+        updates.body = validate('POST body', keys.body, [isValidJson()]);
+      }
     }
 
     if (keys.hasOwnProperty('header')) {
@@ -194,9 +218,7 @@ export default class WebhookRouterForm extends React.Component<
 
     const updated = mergeForm(this.state, updates, toRemove);
 
-    // update our form
     this.setState(updated, () => {
-      // if we updated headers, check if we need a new one
       if (ensureEmptyHeader) {
         let needsHeader = true;
         for (const header of this.state.headers) {
@@ -205,7 +227,6 @@ export default class WebhookRouterForm extends React.Component<
             break;
           }
         }
-
         if (needsHeader) {
           this.handleCreateHeader();
         }
@@ -249,7 +270,6 @@ export default class WebhookRouterForm extends React.Component<
   }
 
   private handleSave(): void {
-    // validate our url in case they haven't interacted
     let valid = false;
     if (this.state.method.value.name === 'FUNCTION') {
       valid = this.handleUpdate({ resultName: this.state.resultName.value }, true);
@@ -280,7 +300,7 @@ export default class WebhookRouterForm extends React.Component<
     const typeConfig = this.props.typeConfig;
 
     const headerElements: JSX.Element[] = this.state.headers.map(
-      (header: HeaderEntry, index: number, arr: HeaderEntry[]) => {
+      (header: HeaderEntry, index: number) => {
         return (
           <div key={`header_${header.value.uuid}`}>
             <HeaderElement
@@ -386,7 +406,8 @@ export default class WebhookRouterForm extends React.Component<
                 options={this.state.webhookOptions.map(webhook => ({
                   name: webhook.name,
                   value: webhook.name,
-                  id: webhook.name
+                  id: webhook.name,
+                  label: webhook.name
                 }))}
               />
             ) : (

--- a/src/components/flow/routers/webhook/WebhookRouterForm.tsx
+++ b/src/components/flow/routers/webhook/WebhookRouterForm.tsx
@@ -16,6 +16,7 @@ import { createResultNameInput } from 'components/flow/routers/widgets';
 import SelectElement from 'components/form/select/SelectElement';
 import TextInputElement from 'components/form/textinput/TextInputElement';
 import TypeList from 'components/nodeeditor/TypeList';
+import TembaSelectElement from 'temba/TembaSelectElement';
 import * as React from 'react';
 import { FormEntry, FormState, mergeForm, StringEntry, ValidationFailure } from 'store/nodeEditor';
 import {
@@ -32,6 +33,7 @@ import { createUUID } from 'utils';
 import styles from './WebhookRouterForm.module.scss';
 import { Trans } from 'react-i18next';
 import i18n from 'config/i18n';
+import { fakePropType } from 'config/ConfigProvider';
 
 export interface HeaderEntry extends FormEntry {
   value: Header;
@@ -47,18 +49,63 @@ export interface WebhookRouterFormState extends FormState {
   url: StringEntry;
   body: StringEntry;
   resultName: StringEntry;
+  webhookFunction: FormEntry;
+  webhookOptions: { name: string; body?: string }[];
 }
 
 export default class WebhookRouterForm extends React.Component<
   RouterFormProps,
   WebhookRouterFormState
 > {
+  public static contextTypes = {
+    config: fakePropType
+  };
+
   constructor(props: RouterFormProps) {
     super(props);
-    this.state = nodeToState(this.props.nodeSettings);
+
+    this.state = {
+      ...nodeToState(this.props.nodeSettings),
+      webhookFunction: { value: null },
+      webhookOptions: []
+    };
+
     bindCallbacks(this, {
       include: [/^handle/]
     });
+  }
+
+  async componentDidMount() {
+    const endpoint = this.context?.config?.endpoints?.completion;
+    if (endpoint) {
+      const response = await fetch(endpoint);
+      const data = await response.json();
+
+      this.setState({ webhookOptions: data.webhook });
+    }
+  }
+
+  private handleWebhookFunctionChanged(selected: any[]): boolean {
+    const updates: Partial<WebhookRouterFormState> = {
+      webhookFunction: { value: selected }
+    };
+
+    if (selected && selected.length > 0) {
+      const webhookName = selected[0].name || selected[0].value || selected[0];
+      const webhook = this.state.webhookOptions.find(w => w.name === webhookName);
+
+      updates.url = { value: webhookName };
+
+      if (webhook && webhook.body) {
+        updates.body = { value: webhook.body };
+      }
+    } else {
+      updates.url = { value: '' };
+    }
+
+    const updated = mergeForm(this.state, updates);
+    this.setState(updated);
+    return updated.valid;
   }
 
   private handleUpdate(
@@ -326,21 +373,31 @@ export default class WebhookRouterForm extends React.Component<
             />
           </div>
           <div className={styles.url}>
-            <TextInputElement
-              name={i18n.t('forms.url', 'URL')}
-              placeholder={
-                method === 'FUNCTION'
-                  ? 'Enter function'
-                  : i18n.t('forms.enter_a_url', 'Enter a URL')
-              }
-              entry={this.state.url}
-              onChange={(url, name) => {
-                method === 'FUNCTION'
-                  ? this.setState({ url: { value: url } })
-                  : this.handleUrlUpdate(url, name);
-              }}
-              autocomplete={true}
-            />
+            {method === 'FUNCTION' ? (
+              <TembaSelectElement
+                key="webhook_function_select"
+                name={i18n.t('forms.function', 'Function')}
+                placeholder={i18n.t('forms.select_or_type', 'Type to search or select')}
+                entry={this.state.webhookFunction}
+                searchable={true}
+                multi={false}
+                expressions={false}
+                onChange={this.handleWebhookFunctionChanged}
+                options={this.state.webhookOptions.map(webhook => ({
+                  name: webhook.name,
+                  value: webhook.name,
+                  id: webhook.name
+                }))}
+              />
+            ) : (
+              <TextInputElement
+                name={i18n.t('forms.url', 'URL')}
+                placeholder={i18n.t('forms.enter_a_url', 'Enter a URL')}
+                entry={this.state.url}
+                onChange={this.handleUrlUpdate}
+                autocomplete={true}
+              />
+            )}
           </div>
         </div>
         <div className={styles.instructions}>

--- a/src/components/flow/routers/webhook/WebhookRouterForm.tsx
+++ b/src/components/flow/routers/webhook/WebhookRouterForm.tsx
@@ -50,7 +50,7 @@ export interface WebhookRouterFormState extends FormState {
   body: StringEntry;
   resultName: StringEntry;
   webhookFunction: FormEntry;
-  webhookOptions: { name: string; body?: string }[];
+  webhookOptions: any[]; //
 }
 
 export default class WebhookRouterForm extends React.Component<
@@ -66,7 +66,6 @@ export default class WebhookRouterForm extends React.Component<
 
     this.state = {
       ...nodeToState(this.props.nodeSettings),
-      webhookFunction: { value: null },
       webhookOptions: []
     };
 
@@ -82,16 +81,27 @@ export default class WebhookRouterForm extends React.Component<
 
     const webhookOptions = (data.webhook || []).map((webhook: any) => ({
       name: webhook.name,
+      value: webhook.name,
+      id: webhook.name,
+      label: webhook.name,
       body: webhook.body
     }));
 
-    this.setState({ webhookOptions });
+    if (this.state.method.value.value === Methods.FUNCTION && this.state.url.value) {
+      const functionName = this.state.url.value;
+      const selectedOption = webhookOptions.find(opt => opt.name === functionName);
+
+      this.setState({
+        webhookOptions,
+        webhookFunction: { value: selectedOption || null }
+      });
+    } else {
+      this.setState({ webhookOptions });
+    }
   }
 
-  private handleWebhookFunctionChanged(selected: any[]): boolean {
-    const selectedArray = !selected ? [] : Array.isArray(selected) ? selected : [selected];
-
-    if (selectedArray.length === 0) {
+  private handleWebhookFunctionChanged(selected: any): boolean {
+    if (!selected) {
       const updates: Partial<WebhookRouterFormState> = {
         webhookFunction: { value: null },
         url: { value: '' },
@@ -102,22 +112,10 @@ export default class WebhookRouterForm extends React.Component<
       return updated.valid;
     }
 
-    const selectedItem = selectedArray[0];
-    const webhookName =
-      typeof selectedItem === 'string'
-        ? selectedItem
-        : selectedItem?.value ||
-          selectedItem?.name ||
-          selectedItem?.id ||
-          selectedItem?.label ||
-          '';
-
-    const webhook = this.state.webhookOptions.find(w => w.name === webhookName);
-
     const updates: Partial<WebhookRouterFormState> = {
-      webhookFunction: { value: selectedArray },
-      url: { value: webhookName },
-      body: { value: webhook?.body || '' }
+      webhookFunction: { value: selected },
+      url: { value: selected?.name || selected?.value || '' },
+      body: { value: selected?.body || '' }
     };
 
     const updated = mergeForm(this.state, updates) as WebhookRouterFormState;
@@ -403,12 +401,7 @@ export default class WebhookRouterForm extends React.Component<
                 multi={false}
                 expressions={false}
                 onChange={this.handleWebhookFunctionChanged}
-                options={this.state.webhookOptions.map(webhook => ({
-                  name: webhook.name,
-                  value: webhook.name,
-                  id: webhook.name,
-                  label: webhook.name
-                }))}
+                options={this.state.webhookOptions}
               />
             ) : (
               <TextInputElement

--- a/src/components/flow/routers/webhook/WebhookRouterForm.tsx
+++ b/src/components/flow/routers/webhook/WebhookRouterForm.tsx
@@ -114,8 +114,8 @@ export default class WebhookRouterForm extends React.Component<
 
     const updates: Partial<WebhookRouterFormState> = {
       webhookFunction: { value: selected },
-      url: { value: selected?.name || selected?.value || '' },
-      body: { value: selected?.body || '' }
+      url: { value: selected.name || selected.value || '' },
+      body: { value: selected.body || '' }
     };
 
     const updated = mergeForm(this.state, updates) as WebhookRouterFormState;

--- a/src/components/flow/routers/webhook/__snapshots__/WebhookRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/webhook/__snapshots__/WebhookRouterForm.test.tsx.snap
@@ -297,6 +297,10 @@ Object {
     "value": "http://domain.com/",
   },
   "valid": true,
+  "webhookFunction": Object {
+    "value": null,
+  },
+  "webhookOptions": Array [],
 }
 `;
 
@@ -345,6 +349,10 @@ Object {
     "value": "http://domain.com/",
   },
   "valid": true,
+  "webhookFunction": Object {
+    "value": null,
+  },
+  "webhookOptions": Array [],
 }
 `;
 

--- a/src/components/flow/routers/webhook/helpers.ts
+++ b/src/components/flow/routers/webhook/helpers.ts
@@ -64,6 +64,7 @@ export const nodeToState = (settings: NodeEditorSettings): WebhookRouterFormStat
     url: { value: '' },
     body: { value: getDefaultBody(Methods.GET) },
     webhookFunction: { value: null },
+    webhookOptions: [],
     valid: false
   };
 

--- a/src/components/flow/routers/webhook/helpers.ts
+++ b/src/components/flow/routers/webhook/helpers.ts
@@ -64,7 +64,6 @@ export const nodeToState = (settings: NodeEditorSettings): WebhookRouterFormStat
     url: { value: '' },
     body: { value: getDefaultBody(Methods.GET) },
     webhookFunction: { value: null },
-    webhookOptions: [],
     valid: false
   };
 

--- a/src/components/flow/routers/webhook/helpers.ts
+++ b/src/components/flow/routers/webhook/helpers.ts
@@ -63,6 +63,8 @@ export const nodeToState = (settings: NodeEditorSettings): WebhookRouterFormStat
     method: { value: GET_METHOD },
     url: { value: '' },
     body: { value: getDefaultBody(Methods.GET) },
+    webhookFunction: { value: null },
+    webhookOptions: [],
     valid: false
   };
 


### PR DESCRIPTION
Target issue: [#3200](https://github.com/glific/glific-frontend/issues/3200)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhook routers can now select remote "function" endpoints instead of a URL, with the UI loading available function options from a remote endpoint and switching inputs accordingly.

* **Bug Fixes / Improvements**
  * Selecting or clearing a function reliably updates webhook fields.
  * Default body/header handling refined; JSON validation is skipped for empty bodies when using function mode and otherwise remains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->