### PR TITLE
Revert default language tab changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@glific/flow-editor",
   "license": "AGPL-3.0",
   "repository": "git://github.com/glific/floweditor.git",
-  "version": "1.43.0-2",
+  "version": "1.43.0-3",
   "description": "'Standalone flow editing tool designed for use within the Glific suite of messaging tools'",
   "browser": "umd/flow-editor.min.js",
   "unpkg": "umd/flow-editor.min.js",

--- a/src/components/languageselector/LanguageSelector.module.scss
+++ b/src/components/languageselector/LanguageSelector.module.scss
@@ -37,7 +37,6 @@
     text-decoration: none;
     color: $gray;
     cursor: default;
-    font-weight: 500;
   }
 }
 

--- a/src/components/languageselector/LanguageSelector.tsx
+++ b/src/components/languageselector/LanguageSelector.tsx
@@ -52,7 +52,6 @@ export class LanguageSelector extends React.Component<LanguageSelectorProps> {
 
     const languages = Object.keys(this.props.languages.items)
       .map((iso: string) => this.props.languages.items[iso])
-      .filter((lang: Asset) => !lang.content?.default)
       .sort(this.handleLanguageSort);
 
     if (languages.length === 1) {

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -371,18 +371,10 @@ export const loadFlowDefinition = (details: FlowDetails, assetStore: AssetStore)
     language = assetStore.languages.items[definition.language];
   }
 
-  const defaultLanguage = Object.values(assetStore.languages.items).find(
-    (lang: any) => lang.content.default
-  );
-
   if (!language) {
-    const defaultTab = {
-      ...DEFAULT_LANGUAGE,
-      name: defaultLanguage ? `Default (${defaultLanguage.name})` : DEFAULT_LANGUAGE.name
-    };
-    language = defaultTab;
-    dispatch(mergeEditorState({ language: defaultTab }));
-    mergeAssetMaps(assetStore.languages.items, { base: defaultTab });
+    language = DEFAULT_LANGUAGE;
+    dispatch(mergeEditorState({ language: DEFAULT_LANGUAGE }));
+    mergeAssetMaps(assetStore.languages.items, { base: DEFAULT_LANGUAGE });
   }
 
   if (details.issues) {


### PR DESCRIPTION
The[ changes to the default language](https://github.com/glific/floweditor/pull/169/files) functionality were not backward compatible. Reverting these changes until we work on a better solution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Default languages now included in the language selector

* **Style**
  * Updated active language indicator styling

* **Chores**
  * Patch version update (1.43.0-3)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->