### PR TITLE
Fix: Expression value not being saved in Wait for Response node

### DIFF
--- a/src/components/form/timeout/TimeoutControl.tsx
+++ b/src/components/form/timeout/TimeoutControl.tsx
@@ -75,7 +75,13 @@ export default class TimeoutControl extends React.Component<TimeoutControlProps>
   }
 
   private handleTimeoutChanged(selected: any): void {
-    this.props.onChanged(parseInt(selected.value));
+    const timeout = parseInt(selected.value);
+
+    if (timeout === 0) {
+      this.props.onChanged(0, this.props.expression);
+    } else {
+      this.props.onChanged(timeout);
+    }
   }
 
   public render(): JSX.Element {

--- a/src/components/form/timeout/TimeoutControl.tsx
+++ b/src/components/form/timeout/TimeoutControl.tsx
@@ -77,8 +77,8 @@ export default class TimeoutControl extends React.Component<TimeoutControlProps>
   private handleTimeoutChanged(selected: any): void {
     const timeout = parseInt(selected.value);
 
-    if (timeout === 0) {
-      this.props.onChanged(0, this.props.expression);
+    if (this.props.expression) {
+      this.props.onChanged(timeout, this.props.expression);
     } else {
       this.props.onChanged(timeout);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timeout control so changing the timeout preserves any expression context. When an expression is active, the change now correctly reports both the numeric timeout and the expression; otherwise it reports the timeout alone. This ensures expression-mode selections are retained and propagated consistently.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->