### PR TITLE
Add custom webhook option

### DIFF
--- a/src/components/flow/routers/webhook/WebhookRouterForm.module.scss
+++ b/src/components/flow/routers/webhook/WebhookRouterForm.module.scss
@@ -98,6 +98,34 @@
   margin-left: 10px;
 }
 
+.custom_function_wrapper {
+  position: relative;
+  width: 100%;
+
+  .toggle_icon {
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    cursor: pointer;
+    color: #999;
+    font-size: 14px;
+    font-weight: 200;
+    font-family: Arial, sans-serif;
+
+    line-height: 1;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    user-select: none;
+
+    &:hover {
+      color: #666;
+    }
+  }
+}
+
 .body_form {
   .req_body {
     margin-top: 8px;

--- a/src/components/flow/routers/webhook/WebhookRouterForm.tsx
+++ b/src/components/flow/routers/webhook/WebhookRouterForm.tsx
@@ -95,9 +95,9 @@ export default class WebhookRouterForm extends React.Component<
         let selectedOption = webhookOptions.find((opt: any) => opt.name === functionName);
         if (!selectedOption) {
           selectedOption = {
-            value: 'custom',
-            name: 'custom',
-            label: 'Custom'
+            value: 'custom_webhook',
+            name: 'custom_webhook',
+            label: 'custom_webhook'
           };
         }
 
@@ -105,7 +105,8 @@ export default class WebhookRouterForm extends React.Component<
           webhookOptions,
           webhookFunction: { value: selectedOption || null },
           url: {
-            value: selectedOption.value === 'custom' ? this.state.url.value : selectedOption.name
+            value:
+              selectedOption.value === 'custom_webhook' ? this.state.url.value : selectedOption.name
           }
         });
       } else {
@@ -119,7 +120,7 @@ export default class WebhookRouterForm extends React.Component<
   }
 
   private handleWebhookFunctionChanged(selected: any): boolean {
-    const isCustom = selected?.value === 'custom';
+    const isCustom = selected?.value === 'custom_webhook';
     const prevFunction = this.state.webhookFunction?.value;
     const prevFunctionName = prevFunction?.name || prevFunction?.value;
 
@@ -438,7 +439,7 @@ export default class WebhookRouterForm extends React.Component<
           <div className={styles.url}>
             {method === 'FUNCTION' ? (
               <>
-                {this.state.webhookFunction?.value?.value === 'custom' ? (
+                {this.state.webhookFunction?.value?.value === 'custom_webhook' ? (
                   <div className={styles.custom_function_wrapper}>
                     <TextInputElement
                       name={i18n.t('forms.custom_function_label', 'Function Name')}

--- a/src/components/flow/routers/webhook/WebhookRouterForm.tsx
+++ b/src/components/flow/routers/webhook/WebhookRouterForm.tsx
@@ -92,11 +92,21 @@ export default class WebhookRouterForm extends React.Component<
 
       if (this.state.method.value.value === Methods.FUNCTION && this.state.url.value) {
         const functionName = this.state.url.value;
-        const selectedOption = webhookOptions.find((opt: any) => opt.name === functionName);
+        let selectedOption = webhookOptions.find((opt: any) => opt.name === functionName);
+        if (!selectedOption) {
+          selectedOption = {
+            value: 'custom',
+            name: 'custom',
+            label: 'Custom'
+          };
+        }
 
         this.setState({
           webhookOptions,
-          webhookFunction: { value: selectedOption || null }
+          webhookFunction: { value: selectedOption || null },
+          url: {
+            value: selectedOption.value === 'custom' ? this.state.url.value : selectedOption.name
+          }
         });
       } else {
         this.setState({ webhookOptions });
@@ -109,15 +119,18 @@ export default class WebhookRouterForm extends React.Component<
   }
 
   private handleWebhookFunctionChanged(selected: any): boolean {
+    const isCustom = selected?.value === 'custom';
     const prevFunction = this.state.webhookFunction?.value;
     const prevFunctionName = prevFunction?.name || prevFunction?.value;
 
     let updates: Partial<WebhookRouterFormState> = {
       webhookFunction: { value: selected },
-      url: { value: selected ? selected.name || selected.value : '' }
+      url: {
+        value: selected ? (isCustom ? '' : selected.name || selected.value) : ''
+      }
     };
 
-    if (selected) {
+    if (selected && !isCustom) {
       const backendDefaultBody = selected.body || '';
       const currentBody = this.state.body.value;
 
@@ -126,6 +139,8 @@ export default class WebhookRouterForm extends React.Component<
       updates.body = {
         value: shouldResetBody ? backendDefaultBody : currentBody
       };
+    } else if (isCustom) {
+      updates.body = { value: '{}' };
     } else {
       updates.body = { value: '' };
     }
@@ -308,7 +323,6 @@ export default class WebhookRouterForm extends React.Component<
 
     if (valid) {
       const payload = stateToNode(this.props.nodeSettings, this.state);
-
       this.props.updateRouter(payload);
 
       this.props.onClose(false);
@@ -423,21 +437,41 @@ export default class WebhookRouterForm extends React.Component<
           </div>
           <div className={styles.url}>
             {method === 'FUNCTION' ? (
-              <TembaSelectElement
-                key="webhook_function_select"
-                name={i18n.t('forms.function', 'Function')}
-                placeholder={
-                  this.state.isLoading
-                    ? 'Loading functions…'
-                    : i18n.t('forms.select_or_type', 'Type to search or select')
-                }
-                entry={this.state.webhookFunction}
-                searchable={true}
-                multi={false}
-                expressions={false}
-                onChange={this.handleWebhookFunctionChanged}
-                options={this.state.webhookOptions}
-              />
+              <>
+                {this.state.webhookFunction?.value?.value === 'custom' ? (
+                  <div className={styles.custom_function_wrapper}>
+                    <TextInputElement
+                      name={i18n.t('forms.custom_function_label', 'Function Name')}
+                      placeholder={i18n.t('forms.enter_label', 'Enter function name')}
+                      entry={this.state.url}
+                      onChange={(v: string) => this.handleUpdate({ url: v })}
+                      autocomplete={true}
+                    />
+                    <div
+                      className={styles.toggle_icon}
+                      onClick={() => this.handleWebhookFunctionChanged(null)}
+                    >
+                      ▾
+                    </div>
+                  </div>
+                ) : (
+                  <TembaSelectElement
+                    key="webhook_function_select"
+                    name={i18n.t('forms.function', 'Function')}
+                    placeholder={
+                      this.state.isLoading
+                        ? 'Loading functions…'
+                        : i18n.t('forms.select_or_type', 'Type to search or select')
+                    }
+                    entry={this.state.webhookFunction}
+                    searchable={true}
+                    multi={false}
+                    expressions={false}
+                    onChange={this.handleWebhookFunctionChanged}
+                    options={this.state.webhookOptions}
+                  />
+                )}
+              </>
             ) : (
               <TextInputElement
                 name={i18n.t('forms.url', 'URL')}


### PR DESCRIPTION
## Summary 
This PR enhances the Webhook Router Form by allowing users to manually input a custom function name when the predefined options from the backend do not meet their needs. This provides greater flexibility for developers using the webhook router in FUNCTION mode.

 ### Changes

1. Conditional Field Switching: Replaced the standard search dropdown with a conditional block. If a user selects the Custom option, the dropdown is swapped for a TextInputElement.
<img width="638" height="277" alt="Screenshot 2025-12-29 at 3 14 10 PM" src="https://github.com/user-attachments/assets/18ae2e7d-aa70-41a7-8c00-2b021ba1627c" />

2-Where you can edit the label name and body.


3. Added a custom wrapper around the text input containing a "light arrow" chevron icon (▾). Clicking this icon resets the state, allowing users to return to the preset search list.

<img width="646" height="163" alt="Screenshot 2025-12-29 at 3 18 08 PM" src="https://github.com/user-attachments/assets/6e0263dc-cda9-4243-88a1-1ec4353a1b49" />
