### PR TITLE
Copy functionality for nodes and actions

### DIFF
--- a/src/components/flow/Flow.tsx
+++ b/src/components/flow/Flow.tsx
@@ -32,6 +32,8 @@ import {
   OnRemoveNodes,
   OnUpdateCanvasPositions,
   onUpdateCanvasPositions,
+  pasteNode,
+  PasteNode,
   resetNodeEditingState,
   UpdateConnection,
   updateConnection,
@@ -81,6 +83,7 @@ export interface FlowStoreProps {
   resetNodeEditingState: NoParamsAC;
   onConnectionDrag: OnConnectionDrag;
   updateSticky: UpdateSticky;
+  pasteNode: PasteNode;
 }
 
 export interface Translations {
@@ -151,7 +154,20 @@ export class Flow extends React.PureComponent<FlowStoreProps, {}> {
     return win.isMobile && win.isMobile();
   }
 
+  private handleKeyDown(event: KeyboardEvent): void {
+    if ((event.ctrlKey || event.metaKey) && event.key === 'v') {
+      const target = event.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') {
+        return;
+      }
+      event.preventDefault();
+      this.props.pasteNode();
+    }
+  }
+
   public componentDidMount(): void {
+    document.addEventListener('keydown', this.handleKeyDown);
+
     this.Plumber.bind('connection', (event: ConnectionEvent) =>
       this.props.updateConnection(event.sourceId, event.targetId)
     );
@@ -178,6 +194,7 @@ export class Flow extends React.PureComponent<FlowStoreProps, {}> {
   }
 
   public componentWillUnmount(): void {
+    document.removeEventListener('keydown', this.handleKeyDown);
     this.Plumber.reset();
     if ((window as any).activityTimeout) {
       clearTimeout((window as any).activityTimeout);
@@ -467,12 +484,10 @@ const mapDispatchToProps = (dispatch: DispatchWithState) =>
       onUpdateCanvasPositions,
       onRemoveNodes,
       updateConnection,
-      updateSticky
+      updateSticky,
+      pasteNode
     },
     dispatch
   );
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Flow);
+export default connect(mapStateToProps, mapDispatchToProps)(Flow);

--- a/src/components/flow/actions/action/Action.tsx
+++ b/src/components/flow/actions/action/Action.tsx
@@ -17,7 +17,9 @@ import {
   moveActionUp,
   OnOpenNodeEditor,
   onOpenNodeEditor,
-  removeAction
+  removeAction,
+  CopyNode,
+  copyNode
 } from 'store/thunks';
 import { createClickHandler, getLocalization } from 'utils';
 
@@ -43,6 +45,7 @@ export interface ActionWrapperStoreProps {
   onOpenNodeEditor: OnOpenNodeEditor;
   removeAction: ActionAC;
   moveActionUp: ActionAC;
+  copyNode: CopyNode;
   scrollToAction: string;
 }
 
@@ -96,6 +99,17 @@ export class ActionWrapper extends React.Component<ActionWrapperProps> {
       event.stopPropagation();
     }
     this.props.moveActionUp(this.props.renderNode.node.uuid, this.props.action);
+  }
+
+  public handleCopy(event: React.MouseEvent<HTMLElement>): void {
+    if (event) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+    // Only show copy on the first action to copy the entire node
+    if (this.props.first) {
+      this.props.copyNode(this.props.renderNode);
+    }
   }
 
   public getAction(): Action {
@@ -196,6 +210,8 @@ export class ActionWrapper extends React.Component<ActionWrapperProps> {
           showRemoval={showRemoval}
           showMove={showMove}
           onMoveUp={this.handleMoveUp}
+          showCopy={!this.props.translating && this.props.first}
+          onCopy={this.handleCopy}
           shouldCancelClick={() => this.props.selected}
         />
         <div className={styles.body + ' ' + actionClass} data-spec={actionBodySpecId}>
@@ -243,16 +259,14 @@ const mapDispatchToProps = (dispatch: DispatchWithState) =>
     {
       onOpenNodeEditor,
       removeAction,
-      moveActionUp
+      moveActionUp,
+      copyNode
     },
     dispatch
   );
 
-const ConnectedActionWrapper = connect(
-  mapStateToProps,
-  mapDispatchToProps,
-  null,
-  { forwardRef: true }
-)(ActionWrapper);
+const ConnectedActionWrapper = connect(mapStateToProps, mapDispatchToProps, null, {
+  forwardRef: true
+})(ActionWrapper);
 
 export default ConnectedActionWrapper;

--- a/src/components/flow/actions/action/__snapshots__/Action.test.ts.snap
+++ b/src/components/flow/actions/action/__snapshots__/Action.test.ts.snap
@@ -17,9 +17,11 @@ exports[`ActionWrapper render should display hybrid style 1`] = `
   >
     <TitleBar
       __className="send_msg"
+      onCopy={[Function]}
       onMoveUp={[Function]}
       onRemoval={[Function]}
       shouldCancelClick={[Function]}
+      showCopy={true}
       showMove={false}
       showRemoval={true}
       title="Send Message"
@@ -49,9 +51,11 @@ exports[`ActionWrapper render should display missing_localization style 1`] = `
   >
     <TitleBar
       __className="send_msg"
+      onCopy={[Function]}
       onMoveUp={[Function]}
       onRemoval={[Function]}
       shouldCancelClick={[Function]}
+      showCopy={false}
       showMove={false}
       showRemoval={false}
       title="Send Message"
@@ -81,9 +85,11 @@ exports[`ActionWrapper render should display not_localizable style 1`] = `
   >
     <TitleBar
       __className="enter_flow"
+      onCopy={[Function]}
       onMoveUp={[Function]}
       onRemoval={[Function]}
       shouldCancelClick={[Function]}
+      showCopy={false}
       showMove={false}
       showRemoval={false}
       title="Enter a Flow"
@@ -113,9 +119,11 @@ exports[`ActionWrapper render should display translating style 1`] = `
   >
     <TitleBar
       __className="send_msg"
+      onCopy={[Function]}
       onMoveUp={[Function]}
       onRemoval={[Function]}
       shouldCancelClick={[Function]}
+      showCopy={false}
       showMove={false}
       showRemoval={false}
       title="Send Message"
@@ -132,9 +140,11 @@ exports[`ActionWrapper render should render self, children with base props 1`] =
 Object {
   "__className": "send_msg",
   "nodeUUID": undefined,
+  "onCopy": [Function],
   "onMoveUp": [Function],
   "onRemoval": [Function],
   "shouldCancelClick": [Function],
+  "showCopy": true,
   "showMove": false,
   "showRemoval": true,
   "title": "Send Message",
@@ -158,9 +168,11 @@ exports[`ActionWrapper render should render self, children with base props 2`] =
   >
     <TitleBar
       __className="send_msg"
+      onCopy={[Function]}
       onMoveUp={[Function]}
       onRemoval={[Function]}
       shouldCancelClick={[Function]}
+      showCopy={true}
       showMove={false}
       showRemoval={true}
       title="Send Message"
@@ -190,9 +202,11 @@ exports[`ActionWrapper render should show move icon 1`] = `
   >
     <TitleBar
       __className="send_msg"
+      onCopy={[Function]}
       onMoveUp={[Function]}
       onRemoval={[Function]}
       shouldCancelClick={[Function]}
+      showCopy={false}
       showMove={true}
       showRemoval={true}
       title="Send Message"

--- a/src/components/flow/actions/action/__snapshots__/Action.test.tsx.snap
+++ b/src/components/flow/actions/action/__snapshots__/Action.test.tsx.snap
@@ -35,6 +35,10 @@ exports[`ActionWrapper can have localized quick replies when empty on default la
                
             </div>
             <div
+              class="copy_button"
+              data-testid="copy-icon"
+            />
+            <div
               class="remove_button"
               data-testid="remove-icon"
             />
@@ -108,6 +112,15 @@ exports[`ActionWrapper renders a base language 1`] = `
             >
               Send Message
                
+            </div>
+            <div
+              class="copy_button"
+              data-testid="copy-icon"
+            >
+              <temba-icon
+                name="copy"
+                size="1.2"
+              />
             </div>
             <div
               class="remove_button"

--- a/src/components/flow/node/Node.tsx
+++ b/src/components/flow/node/Node.tsx
@@ -33,7 +33,9 @@ import {
   OnOpenNodeEditor,
   onOpenNodeEditor,
   RemoveNode,
-  removeNode
+  removeNode,
+  CopyNode,
+  copyNode
 } from 'store/thunks';
 import { ClickHandler, createClickHandler } from 'utils';
 
@@ -75,6 +77,7 @@ export interface NodeStoreProps {
   onAddToNode: OnAddToNode;
   onOpenNodeEditor: OnOpenNodeEditor;
   removeNode: RemoveNode;
+  copyNode: CopyNode;
   mergeEditorState: MergeEditorState;
   scrollToNode: string;
   scrollToAction: string;
@@ -209,6 +212,12 @@ export class NodeComp extends React.PureComponent<NodeProps> {
     event.preventDefault();
     event.stopPropagation();
     this.props.removeNode(this.props.renderNode.node);
+  }
+
+  private handleCopy(event: React.MouseEvent<HTMLElement>): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.props.copyNode(this.props.renderNode);
   }
 
   private getExits(): JSX.Element[] {
@@ -370,6 +379,8 @@ export class NodeComp extends React.PureComponent<NodeProps> {
                 nodeUUID={showLabel && this.props.nodeUUID}
                 showRemoval={!this.props.translating}
                 onRemoval={this.handleRemoval}
+                showCopy={!this.props.translating}
+                onCopy={this.handleCopy}
                 shouldCancelClick={this.handleShouldCancelClick}
                 title={title}
               />
@@ -542,14 +553,10 @@ const mapDispatchToProps = (dispatch: DispatchWithState) =>
       onAddToNode,
       onOpenNodeEditor,
       removeNode,
+      copyNode,
       mergeEditorState
     },
     dispatch
   );
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-  null,
-  { forwardRef: true }
-)(NodeComp);
+export default connect(mapStateToProps, mapDispatchToProps, null, { forwardRef: true })(NodeComp);

--- a/src/components/flow/node/__snapshots__/Node.test.tsx.snap
+++ b/src/components/flow/node/__snapshots__/Node.test.tsx.snap
@@ -138,6 +138,15 @@ exports[`NodeComp renders a named random split 1`] = `
                      
                   </div>
                   <div
+                    class="copy_button"
+                    data-testid="copy-icon"
+                  >
+                    <temba-icon
+                      name="copy"
+                      size="1.2"
+                    />
+                  </div>
+                  <div
                     class="remove_button"
                     data-testid="remove-icon"
                   >

--- a/src/components/titlebar/TitleBar.module.scss
+++ b/src/components/titlebar/TitleBar.module.scss
@@ -37,12 +37,26 @@
     }
   }
 
+  .copy_button {
+    padding-right: 5px;
+    width: 20px;
+    color: rgba(255, 255, 255, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.2s;
+  }
+
   .remove_button {
     padding-right: 0px;
     visibility: hidden;
     width: 20px;
-    right: 0;
     color: rgba(255, 255, 255, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   .up_button {
@@ -53,6 +67,10 @@
   }
 
   &:hover {
+    .copy_button {
+      opacity: 1;
+    }
+
     .remove_button {
       visibility: visible;
     }

--- a/src/components/titlebar/TitleBar.tsx
+++ b/src/components/titlebar/TitleBar.tsx
@@ -13,6 +13,8 @@ export interface TitleBarProps {
   showRemoval?: boolean;
   showMove?: boolean;
   onMoveUp?(event: React.MouseEvent<HTMLElement>): any;
+  onCopy?(event: React.MouseEvent<HTMLElement>): any;
+  showCopy?: boolean;
   shouldCancelClick?: () => boolean;
 }
 
@@ -106,6 +108,26 @@ export default class TitleBar extends React.Component<TitleBarProps, TitleBarSta
     return moveArrow;
   }
 
+  private getCopy(): JSX.Element {
+    if (this.props.showCopy && this.context.config.mutable && this.props.onCopy) {
+      return (
+        <div
+          className={styles.copy_button}
+          {...createClickHandler(
+            this.props.onCopy,
+            this.props.shouldCancelClick,
+            this.handleMouseUpCapture
+          )}
+          data-testid="copy-icon"
+        >
+          <temba-icon name="copy" size="1.2"></temba-icon>
+        </div>
+      );
+    }
+
+    return <div className={styles.copy_button} data-testid="copy-icon"></div>;
+  }
+
   private getRemove(): JSX.Element {
     let remove: JSX.Element = (
       <div className={styles.remove_button} data-testid={removeIconSpecId}></div>
@@ -159,6 +181,7 @@ export default class TitleBar extends React.Component<TitleBarProps, TitleBarSta
   public render(): JSX.Element {
     const confirmation: JSX.Element = this.getConfirmationEl();
     const moveArrow: JSX.Element = this.getMoveArrow();
+    const copy: JSX.Element = this.getCopy();
     const remove: JSX.Element = this.getRemove();
     return (
       <div className={styles.titlebar} data-spec={titlebarContainerSpecId}>
@@ -167,6 +190,7 @@ export default class TitleBar extends React.Component<TitleBarProps, TitleBarSta
           <div className={styles.titletext}>
             {this.props.title} {this.props.nodeUUID && `: ${this.props.nodeUUID.slice(-4)}`}
           </div>
+          {copy}
           {remove}
         </div>
         {confirmation}

--- a/src/components/titlebar/__snapshots__/TitleBar.test.tsx.snap
+++ b/src/components/titlebar/__snapshots__/TitleBar.test.tsx.snap
@@ -32,6 +32,10 @@ exports[`TitleBar render confirmation should render confirmation markup 1`] = `
            
         </div>
         <div
+          class="copy_button"
+          data-testid="copy-icon"
+        />
+        <div
           class="remove_button"
           data-testid="remove-icon"
         >
@@ -100,6 +104,10 @@ exports[`TitleBar render move icon should call onMoveUp 1`] = `
            
         </div>
         <div
+          class="copy_button"
+          data-testid="copy-icon"
+        />
+        <div
           class="remove_button"
           data-testid="remove-icon"
         />
@@ -135,6 +143,10 @@ exports[`TitleBar render move icon should render move icon 1`] = `
         Send Message
          
       </div>
+      <div
+        class="copy_button"
+        data-testid="copy-icon"
+      />
       <div
         class="remove_button"
         data-testid="remove-icon"
@@ -175,6 +187,10 @@ exports[`TitleBar render remove icon should render remove icon 1`] = `
            
         </div>
         <div
+          class="copy_button"
+          data-testid="copy-icon"
+        />
+        <div
           class="remove_button"
           data-testid="remove-icon"
         >
@@ -211,6 +227,10 @@ exports[`TitleBar render should apply _className prop 1`] = `
          
       </div>
       <div
+        class="copy_button"
+        data-testid="copy-icon"
+      />
+      <div
         class="remove_button"
         data-testid="remove-icon"
       />
@@ -239,6 +259,10 @@ exports[`TitleBar render should render self, children with base props 1`] = `
         Send Message
          
       </div>
+      <div
+        class="copy_button"
+        data-testid="copy-icon"
+      />
       <div
         class="remove_button"
         data-testid="remove-icon"

--- a/src/store/thunks.test.ts
+++ b/src/store/thunks.test.ts
@@ -16,6 +16,7 @@ import { getFlowComponents, getNodeWithAction, getUniqueDestinations } from 'sto
 import { NodeEditorSettings } from 'store/nodeEditor';
 import { initialState } from 'store/state';
 import {
+  copyNode,
   disconnectExit,
   handleTypeConfigChange,
   loadFlowDefinition,
@@ -27,6 +28,7 @@ import {
   onUpdateAction,
   onUpdateLocalizations,
   onUpdateRouter,
+  pasteNode,
   removeAction,
   removeNode,
   resetNodeEditingState,
@@ -201,6 +203,171 @@ describe('Flow Manipulation', () => {
         )
       );
       expect(store.getActions()).toMatchSnapshot();
+    });
+
+    describe('copy and paste', () => {
+      beforeEach(() => {
+        store = createMockStore(
+          mutate(initialState, {
+            flowContext: {
+              nodes: { $set: testNodes },
+              assetStore: { $set: { results: { items: {} } } }
+            }
+          })
+        );
+        localStorage.clear();
+      });
+
+      afterEach(() => {
+        localStorage.clear();
+      });
+
+      describe('copyNode', () => {
+        it('should add the copied action node to the flow with fresh UUIDs', () => {
+          const sourceNode = testNodes.node3;
+          store.dispatch(copyNode(sourceNode));
+
+          const updatedNodes = getUpdatedNodes(store);
+
+          // original node is still present
+          expect(updatedNodes.node3).toBeDefined();
+
+          // a new node was added
+          const copiedUUID = Object.keys(updatedNodes).find(
+            uuid => uuid !== sourceNode.node.uuid && !testNodes[uuid]
+          );
+          expect(copiedUUID).toBeDefined();
+
+          const copiedNode = updatedNodes[copiedUUID];
+
+          // node UUID is fresh
+          expect(copiedNode.node.uuid).not.toBe(sourceNode.node.uuid);
+
+          // action UUIDs are fresh
+          copiedNode.node.actions.forEach((action: any, idx: number) => {
+            expect(action.uuid).not.toBe(sourceNode.node.actions[idx].uuid);
+          });
+
+          // exit UUIDs are fresh and destination is cleared
+          copiedNode.node.exits.forEach((exit: any, idx: number) => {
+            expect(exit.uuid).not.toBe(sourceNode.node.exits[idx].uuid);
+            expect(exit.destination_uuid).toBeNull();
+          });
+
+          // no inbound connections on the copy
+          expect(copiedNode.inboundConnections).toEqual({});
+        });
+
+        it('should offset the position of the copied node by NODE_SPACING * 2', () => {
+          const sourceNode = testNodes.node3;
+          store.dispatch(copyNode(sourceNode));
+
+          const updatedNodes = getUpdatedNodes(store);
+          const copiedUUID = Object.keys(updatedNodes).find(uuid => !testNodes[uuid]);
+          const copiedNode = updatedNodes[copiedUUID];
+
+          expect(copiedNode.ui.position.left).toBe(sourceNode.ui.position.left + 20);
+          expect(copiedNode.ui.position.top).toBe(sourceNode.ui.position.top + 20);
+        });
+
+        it('should correctly remap internal UUIDs for a router node', () => {
+          const sourceNode = testNodes.node1;
+          store.dispatch(copyNode(sourceNode));
+
+          const updatedNodes = getUpdatedNodes(store);
+          const copiedUUID = Object.keys(updatedNodes).find(uuid => !testNodes[uuid]);
+          const copiedNode = updatedNodes[copiedUUID];
+
+          const originalRouter = sourceNode.node.router as any;
+          const copiedRouter = copiedNode.node.router as any;
+
+          // each category gets a new UUID
+          copiedRouter.categories.forEach((cat: any, idx: number) => {
+            expect(cat.uuid).not.toBe(originalRouter.categories[idx].uuid);
+            // its exit_uuid must point to a real exit on the copied node
+            const matchingExit = copiedNode.node.exits.find((e: any) => e.uuid === cat.exit_uuid);
+            expect(matchingExit).toBeDefined();
+          });
+
+          // each case gets a new UUID
+          copiedRouter.cases.forEach((c: any, idx: number) => {
+            expect(c.uuid).not.toBe(originalRouter.cases[idx].uuid);
+            // its category_uuid must point to a real category on the copied router
+            const matchingCat = copiedRouter.categories.find(
+              (cat: any) => cat.uuid === c.category_uuid
+            );
+            expect(matchingCat).toBeDefined();
+          });
+        });
+
+        it('should save the source node to localStorage', () => {
+          const sourceNode = testNodes.node3;
+          store.dispatch(copyNode(sourceNode));
+
+          const stored = localStorage.getItem('floweditor_copied_node');
+          expect(stored).not.toBeNull();
+          expect(JSON.parse(stored)).toEqual(sourceNode);
+        });
+
+        it('should dispatch UPDATE_NODES', () => {
+          store.dispatch(copyNode(testNodes.node3));
+          expect(store).toHaveReduxActions([Constants.UPDATE_NODES]);
+        });
+      });
+
+      describe('pasteNode', () => {
+        it('should return null when the clipboard is empty', () => {
+          const result = store.dispatch(pasteNode());
+          expect(result).toBeNull();
+        });
+
+        it('should not dispatch UPDATE_NODES when the clipboard is empty', () => {
+          store.dispatch(pasteNode());
+          expect(store).not.toHaveReduxActions([Constants.UPDATE_NODES]);
+        });
+
+        it('should add a new node from clipboard into the current flow', () => {
+          localStorage.setItem('floweditor_copied_node', JSON.stringify(testNodes.node3));
+          store.dispatch(pasteNode());
+
+          const updatedNodes = getUpdatedNodes(store);
+
+          // original node is still present
+          expect(updatedNodes.node3).toBeDefined();
+
+          // a new node was added
+          const pastedUUID = Object.keys(updatedNodes).find(uuid => !testNodes[uuid]);
+          expect(pastedUUID).toBeDefined();
+        });
+
+        it('should paste a node with fresh UUIDs different from the clipboard source', () => {
+          const sourceNode = testNodes.node3;
+          localStorage.setItem('floweditor_copied_node', JSON.stringify(sourceNode));
+          store.dispatch(pasteNode());
+
+          const updatedNodes = getUpdatedNodes(store);
+          const pastedUUID = Object.keys(updatedNodes).find(uuid => !testNodes[uuid]);
+          const pastedNode = updatedNodes[pastedUUID];
+
+          expect(pastedNode.node.uuid).not.toBe(sourceNode.node.uuid);
+          expect(pastedNode.node.actions[0].uuid).not.toBe(sourceNode.node.actions[0].uuid);
+          expect(pastedNode.node.exits[0].uuid).not.toBe(sourceNode.node.exits[0].uuid);
+          expect(pastedNode.node.exits[0].destination_uuid).toBeNull();
+          expect(pastedNode.inboundConnections).toEqual({});
+        });
+
+        it('should dispatch UPDATE_NODES when pasting a valid clipboard node', () => {
+          localStorage.setItem('floweditor_copied_node', JSON.stringify(testNodes.node3));
+          store.dispatch(pasteNode());
+          expect(store).toHaveReduxActions([Constants.UPDATE_NODES]);
+        });
+
+        it('should return null for malformed clipboard data', () => {
+          localStorage.setItem('floweditor_copied_node', 'invalid{json');
+          const result = store.dispatch(pasteNode());
+          expect(result).toBeNull();
+        });
+      });
     });
 
     describe('removal', () => {

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -965,18 +965,14 @@ export const copyNode = (nodeToCopy: RenderNode) => (
     flowContext: { nodes }
   } = getState();
 
-  // Deep clone the node
   const clonedNode: RenderNode = JSON.parse(JSON.stringify(nodeToCopy));
 
-  // Create UUID mapping for all UUIDs that need to be remapped
   const uuidMap: { [oldUUID: string]: string } = {};
 
-  // Remap node UUID
   const newNodeUUID = createUUID();
   uuidMap[clonedNode.node.uuid] = newNodeUUID;
   clonedNode.node.uuid = newNodeUUID;
 
-  // Remap action UUIDs
   if (clonedNode.node.actions) {
     clonedNode.node.actions.forEach((action: AnyAction) => {
       const newActionUUID = createUUID();
@@ -985,18 +981,16 @@ export const copyNode = (nodeToCopy: RenderNode) => (
     });
   }
 
-  // Remap exit UUIDs
   if (clonedNode.node.exits) {
     clonedNode.node.exits.forEach((exit: Exit) => {
       const newExitUUID = createUUID();
       uuidMap[exit.uuid] = newExitUUID;
       exit.uuid = newExitUUID;
-      // Clear destination since it's a copy
+
       exit.destination_uuid = null;
     });
   }
 
-  // Remap router category and case UUIDs if router exists
   if (clonedNode.node.router) {
     const router = clonedNode.node.router as SwitchRouter;
 
@@ -1006,7 +1000,6 @@ export const copyNode = (nodeToCopy: RenderNode) => (
         uuidMap[category.uuid] = newCategoryUUID;
         category.uuid = newCategoryUUID;
 
-        // Remap exit_uuid reference
         if (uuidMap[category.exit_uuid]) {
           category.exit_uuid = uuidMap[category.exit_uuid];
         }
@@ -1019,32 +1012,25 @@ export const copyNode = (nodeToCopy: RenderNode) => (
         uuidMap[caseItem.uuid] = newCaseUUID;
         caseItem.uuid = newCaseUUID;
 
-        // Remap category_uuid reference
         if (uuidMap[caseItem.category_uuid]) {
           caseItem.category_uuid = uuidMap[caseItem.category_uuid];
         }
       });
     }
 
-    // Remap default_category_uuid
     if (router.default_category_uuid && uuidMap[router.default_category_uuid]) {
       router.default_category_uuid = uuidMap[router.default_category_uuid];
     }
   }
 
-  // Offset position to avoid overlap (offset by NODE_SPACING)
   clonedNode.ui.position = {
     left: clonedNode.ui.position.left + NODE_SPACING * 2,
     top: clonedNode.ui.position.top + NODE_SPACING * 2
   };
 
-  // Clear inbound connections since it's a copy
   clonedNode.inboundConnections = {};
-
-  // Remove ghost flag if present
   delete clonedNode.ghost;
 
-  // Add the copied node to the flow
   const updatedNodes = mutators.mergeNode(nodes, clonedNode);
   dispatch(updateNodes(updatedNodes));
   markDirty();

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -100,6 +100,8 @@ export type RemoveNode = (nodeToRemove: FlowNode) => Thunk<RenderNodeMap>;
 
 export type CopyNode = (nodeToCopy: RenderNode) => Thunk<RenderNodeMap>;
 
+export type PasteNode = () => Thunk<RenderNodeMap | null>;
+
 export type UpdateDimensions = (uuid: string, dimensions: Dimensions) => Thunk<void>;
 
 export type FetchFlow = (
@@ -953,19 +955,14 @@ export const onRemoveNodes = (uuids: string[]) => (
   return nodes;
 };
 
-/**
- * Creates a deep copy of a node with new UUIDs and offset position
- * @param nodeToCopy the RenderNode to copy
- */
-export const copyNode = (nodeToCopy: RenderNode) => (
-  dispatch: DispatchWithState,
-  getState: GetState
-): RenderNodeMap => {
-  const {
-    flowContext: { nodes }
-  } = getState();
+const COPIED_NODE_KEY = 'floweditor_copied_node';
 
-  const clonedNode: RenderNode = JSON.parse(JSON.stringify(nodeToCopy));
+/**
+ * Deep-clones a RenderNode, assigning fresh UUIDs to all node/action/exit/router
+ * sub-elements and clearing inbound connections and ghost state.
+ */
+const cloneNodeWithNewUUIDs = (source: RenderNode): RenderNode => {
+  const clonedNode: RenderNode = JSON.parse(JSON.stringify(source));
 
   const uuidMap: { [oldUUID: string]: string } = {};
 
@@ -986,7 +983,6 @@ export const copyNode = (nodeToCopy: RenderNode) => (
       const newExitUUID = createUUID();
       uuidMap[exit.uuid] = newExitUUID;
       exit.uuid = newExitUUID;
-
       exit.destination_uuid = null;
     });
   }
@@ -1030,6 +1026,62 @@ export const copyNode = (nodeToCopy: RenderNode) => (
 
   clonedNode.inboundConnections = {};
   delete clonedNode.ghost;
+
+  return clonedNode;
+};
+
+/**
+ * Creates a deep copy of a node with new UUIDs and offset position.
+ * Also persists the original node data to localStorage so it can be
+ * pasted into a different flow via pasteNode / Ctrl+V.
+ * @param nodeToCopy the RenderNode to copy
+ */
+export const copyNode = (nodeToCopy: RenderNode) => (
+  dispatch: DispatchWithState,
+  getState: GetState
+): RenderNodeMap => {
+  const {
+    flowContext: { nodes }
+  } = getState();
+
+  // Persist the source node so it can be pasted across flows
+  localStorage.setItem(COPIED_NODE_KEY, JSON.stringify(nodeToCopy));
+
+  const clonedNode = cloneNodeWithNewUUIDs(nodeToCopy);
+
+  const updatedNodes = mutators.mergeNode(nodes, clonedNode);
+  dispatch(updateNodes(updatedNodes));
+  markDirty();
+
+  return updatedNodes;
+};
+
+/**
+ * Pastes the most-recently copied node (from localStorage) into the current flow.
+ * This enables cross-flow copy-paste: copy in Flow A, navigate to Flow B, Ctrl+V.
+ * Returns null if there is nothing in the clipboard.
+ */
+export const pasteNode: PasteNode = () => (
+  dispatch: DispatchWithState,
+  getState: GetState
+): RenderNodeMap | null => {
+  const raw = localStorage.getItem(COPIED_NODE_KEY);
+  if (!raw) {
+    return null;
+  }
+
+  const {
+    flowContext: { nodes }
+  } = getState();
+
+  let sourceNode: RenderNode;
+  try {
+    sourceNode = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  const clonedNode = cloneNodeWithNewUUIDs(sourceNode);
 
   const updatedNodes = mutators.mergeNode(nodes, clonedNode);
   dispatch(updateNodes(updatedNodes));

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -10,6 +10,7 @@ import {
   Action,
   AnyAction,
   Category,
+  Case,
   Dimensions,
   Endpoints,
   Exit,
@@ -19,6 +20,7 @@ import {
   SetContactField,
   SetRunResult,
   StickyNote,
+  SwitchRouter,
   FlowDetails
 } from 'flowTypes';
 import mutate from 'immutability-helper';
@@ -95,6 +97,8 @@ export type OnRemoveNodes = (nodeUUIDs: string[]) => Thunk<RenderNodeMap>;
 export type AddAsset = (assetType: string, asset: Asset) => Thunk<void>;
 
 export type RemoveNode = (nodeToRemove: FlowNode) => Thunk<RenderNodeMap>;
+
+export type CopyNode = (nodeToCopy: RenderNode) => Thunk<RenderNodeMap>;
 
 export type UpdateDimensions = (uuid: string, dimensions: Dimensions) => Thunk<void>;
 
@@ -947,6 +951,105 @@ export const onRemoveNodes = (uuids: string[]) => (
   }
 
   return nodes;
+};
+
+/**
+ * Creates a deep copy of a node with new UUIDs and offset position
+ * @param nodeToCopy the RenderNode to copy
+ */
+export const copyNode = (nodeToCopy: RenderNode) => (
+  dispatch: DispatchWithState,
+  getState: GetState
+): RenderNodeMap => {
+  const {
+    flowContext: { nodes }
+  } = getState();
+
+  // Deep clone the node
+  const clonedNode: RenderNode = JSON.parse(JSON.stringify(nodeToCopy));
+
+  // Create UUID mapping for all UUIDs that need to be remapped
+  const uuidMap: { [oldUUID: string]: string } = {};
+
+  // Remap node UUID
+  const newNodeUUID = createUUID();
+  uuidMap[clonedNode.node.uuid] = newNodeUUID;
+  clonedNode.node.uuid = newNodeUUID;
+
+  // Remap action UUIDs
+  if (clonedNode.node.actions) {
+    clonedNode.node.actions.forEach((action: AnyAction) => {
+      const newActionUUID = createUUID();
+      uuidMap[action.uuid] = newActionUUID;
+      action.uuid = newActionUUID;
+    });
+  }
+
+  // Remap exit UUIDs
+  if (clonedNode.node.exits) {
+    clonedNode.node.exits.forEach((exit: Exit) => {
+      const newExitUUID = createUUID();
+      uuidMap[exit.uuid] = newExitUUID;
+      exit.uuid = newExitUUID;
+      // Clear destination since it's a copy
+      exit.destination_uuid = null;
+    });
+  }
+
+  // Remap router category and case UUIDs if router exists
+  if (clonedNode.node.router) {
+    const router = clonedNode.node.router as SwitchRouter;
+
+    if (router.categories) {
+      router.categories.forEach((category: Category) => {
+        const newCategoryUUID = createUUID();
+        uuidMap[category.uuid] = newCategoryUUID;
+        category.uuid = newCategoryUUID;
+
+        // Remap exit_uuid reference
+        if (uuidMap[category.exit_uuid]) {
+          category.exit_uuid = uuidMap[category.exit_uuid];
+        }
+      });
+    }
+
+    if (router.cases) {
+      router.cases.forEach((caseItem: Case) => {
+        const newCaseUUID = createUUID();
+        uuidMap[caseItem.uuid] = newCaseUUID;
+        caseItem.uuid = newCaseUUID;
+
+        // Remap category_uuid reference
+        if (uuidMap[caseItem.category_uuid]) {
+          caseItem.category_uuid = uuidMap[caseItem.category_uuid];
+        }
+      });
+    }
+
+    // Remap default_category_uuid
+    if (router.default_category_uuid && uuidMap[router.default_category_uuid]) {
+      router.default_category_uuid = uuidMap[router.default_category_uuid];
+    }
+  }
+
+  // Offset position to avoid overlap (offset by NODE_SPACING)
+  clonedNode.ui.position = {
+    left: clonedNode.ui.position.left + NODE_SPACING * 2,
+    top: clonedNode.ui.position.top + NODE_SPACING * 2
+  };
+
+  // Clear inbound connections since it's a copy
+  clonedNode.inboundConnections = {};
+
+  // Remove ghost flag if present
+  delete clonedNode.ghost;
+
+  // Add the copied node to the flow
+  const updatedNodes = mutators.mergeNode(nodes, clonedNode);
+  dispatch(updateNodes(updatedNodes));
+  markDirty();
+
+  return updatedNodes;
 };
 
 export const onUpdateCanvasPositions = (positions: CanvasPositions) => (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added copy functionality for nodes and actions. Users can duplicate nodes and actions in the flow editor; copies preserve structure and content and are placed offset from the original.

* **Style**
  * Added styling for a new copy button control that appears on hover in node and action headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->