### PR TITLE
Add custom webhook function support and refactor fetch logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@glific/flow-editor",
   "license": "AGPL-3.0",
   "repository": "git://github.com/glific/floweditor.git",
-  "version": "1.43.0-9",
+  "version": "1.43.0-10",
   "description": "'Standalone flow editing tool designed for use within the Glific suite of messaging tools'",
   "browser": "umd/flow-editor.min.js",
   "unpkg": "umd/flow-editor.min.js",

--- a/src/components/flow/routers/webhook/WebhookRouterForm.tsx
+++ b/src/components/flow/routers/webhook/WebhookRouterForm.tsx
@@ -10,7 +10,8 @@ import {
   nodeToState,
   stateToNode,
   getDefaultBody,
-  isValidJson
+  isValidJson,
+  fetchWebhookOptions
 } from 'components/flow/routers/webhook/helpers';
 import { createResultNameInput } from 'components/flow/routers/widgets';
 import SelectElement from 'components/form/select/SelectElement';
@@ -34,7 +35,6 @@ import styles from './WebhookRouterForm.module.scss';
 import { Trans } from 'react-i18next';
 import i18n from 'config/i18n';
 import { fakePropType } from 'config/ConfigProvider';
-import axios from 'axios';
 
 export interface HeaderEntry extends FormEntry {
   value: Header;
@@ -79,31 +79,10 @@ export default class WebhookRouterForm extends React.Component<
     const endpoint = this.context.config.endpoints.completion;
     this.setState({ isLoading: true });
     try {
-      const response = await axios.get(endpoint);
-      const data = response.data;
-
-      const webhookOptions = (data.webhook || []).map((webhook: any) => ({
-        name: webhook.name,
-        value: webhook.name,
-        id: webhook.name,
-        label: webhook.name,
-        body: webhook.body
-      }));
-
-      if (this.state.method.value.value === Methods.FUNCTION && this.state.url.value) {
-        const functionName = this.state.url.value;
-        const selectedOption = webhookOptions.find((opt: any) => opt.name === functionName);
-
-        this.setState({
-          webhookOptions,
-          webhookFunction: { value: selectedOption || null }
-        });
-      } else {
-        this.setState({ webhookOptions });
-      }
+      const stateUpdate = await fetchWebhookOptions(endpoint, this.state.url.value);
+      this.setState(stateUpdate);
     } catch (error) {
       console.error('Error fetching webhook options:', error);
-    } finally {
       this.setState({ isLoading: false });
     }
   }
@@ -402,7 +381,7 @@ export default class WebhookRouterForm extends React.Component<
     });
 
     tabs.reverse();
-
+    console.log(this.state.webhookFunction);
     return (
       <Dialog
         title={typeConfig.name}
@@ -437,6 +416,12 @@ export default class WebhookRouterForm extends React.Component<
                 expressions={false}
                 onChange={this.handleWebhookFunctionChanged}
                 options={this.state.webhookOptions}
+                allowCreate={true}
+                createArbitraryOption={val => {
+                  this.handleWebhookFunctionChanged({ name: val, value: val });
+                  return { name: val, value: val, id: val, label: val };
+                }}
+                createPrefix={i18n.t('select_function', 'Select Function') + ': '}
               />
             ) : (
               <TextInputElement

--- a/src/components/flow/routers/webhook/WebhookRouterForm.tsx
+++ b/src/components/flow/routers/webhook/WebhookRouterForm.tsx
@@ -84,6 +84,8 @@ export default class WebhookRouterForm extends React.Component<
     } catch (error) {
       console.error('Error fetching webhook options:', error);
       this.setState({ isLoading: false });
+    } finally {
+      this.setState({ isLoading: false });
     }
   }
 

--- a/src/components/flow/routers/webhook/WebhookRouterForm.tsx
+++ b/src/components/flow/routers/webhook/WebhookRouterForm.tsx
@@ -381,7 +381,7 @@ export default class WebhookRouterForm extends React.Component<
     });
 
     tabs.reverse();
-    console.log(this.state.webhookFunction);
+
     return (
       <Dialog
         title={typeConfig.name}

--- a/src/components/flow/routers/webhook/helpers.ts
+++ b/src/components/flow/routers/webhook/helpers.ts
@@ -7,6 +7,7 @@ import { RenderNode } from 'store/flowContext';
 import { NodeEditorSettings, StringEntry } from 'store/nodeEditor';
 import { ValidatorFunc } from 'store/validators';
 import { createUUID } from 'utils';
+import axios from 'axios';
 
 export enum Methods {
   GET = 'GET',
@@ -155,6 +156,52 @@ export const stateToNode = (
 
 export const getDefaultBody = (method: string): string => {
   return method === Methods.GET ? '' : DEFAULT_BODY;
+};
+
+export interface WebhookOption {
+  name: string;
+  value: string;
+  id: string;
+  label: string;
+  body?: string;
+}
+
+export const fetchWebhookOptions = async (
+  endpoint: string,
+  currentUrl: string
+): Promise<Pick<WebhookRouterFormState, 'webhookOptions' | 'webhookFunction' | 'isLoading'>> => {
+  const response = await axios.get(endpoint);
+  const data = response.data;
+
+  const webhookOptions: WebhookOption[] = (data.webhook || []).map((webhook: any) => ({
+    name: webhook.name,
+    value: webhook.name,
+    id: webhook.name,
+    label: webhook.name,
+    body: webhook.body
+  }));
+
+  const stateUpdate: Pick<
+    WebhookRouterFormState,
+    'webhookOptions' | 'webhookFunction' | 'isLoading'
+  > = {
+    webhookOptions,
+    webhookFunction: { value: null },
+    isLoading: false
+  };
+
+  if (currentUrl) {
+    stateUpdate.webhookFunction = {
+      value: {
+        name: currentUrl,
+        value: currentUrl,
+        id: currentUrl,
+        label: currentUrl
+      }
+    };
+  }
+
+  return stateUpdate;
 };
 
 export const isValidJson = (): ValidatorFunc => (name, body: any) => {

--- a/src/components/flow/routers/webhook/helpers.ts
+++ b/src/components/flow/routers/webhook/helpers.ts
@@ -173,13 +173,14 @@ export const fetchWebhookOptions = async (
   const response = await axios.get(endpoint);
   const data = response.data;
 
-  const webhookOptions: WebhookOption[] = (data.webhook || []).map((webhook: any) => ({
-    name: webhook.name,
-    value: webhook.name,
-    id: webhook.name,
-    label: webhook.name,
-    body: webhook.body
-  }));
+  const webhookOptions: WebhookOption[] =
+    data.webhook.map((webhook: any) => ({
+      name: webhook.name,
+      value: webhook.name,
+      id: webhook.name,
+      label: webhook.name,
+      body: webhook.body
+    })) ?? [];
 
   const stateUpdate: Pick<
     WebhookRouterFormState,


### PR DESCRIPTION
Summary

- Add ability to create custom webhook functions via the function dropdown (closes #194)
- Extracted webhook options fetching and state computation from componentDidMount into a fetchWebhookOptions helper in helpers.ts
- Consolidated multiple setState calls into a single update for consistent state transitions
- Moved axios dependency out of the form component into the helper


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhook function selector now lets users create custom webhook entries directly from the configuration UI, with configurable creation/labeling behavior.
  * Dropdown creation flow returns and displays newly created entries immediately.

* **Bug Fixes / Improvements**
  * Webhook options are now fetched via a centralized helper and populated more reliably on form load, with improved loading and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->