### PR TITLE
Fix: Update state handling for Expression template in SendMsgForm

### DIFF
--- a/src/components/flow/actions/sendmsg/SendMsgForm.tsx
+++ b/src/components/flow/actions/sendmsg/SendMsgForm.tsx
@@ -226,7 +226,12 @@ export default class SendMsgForm extends React.Component<ActionFormProps, SendMs
   private handleTemplateChanged(template: any): void {
     if (template) {
       if (template.name === 'Expression') {
-        this.setState({ expression: { value: this.state.expression.value } });
+        this.setState({
+          expression: { value: this.state.expression ? this.state.expression.value : '' },
+          template: { value: template },
+          templateTranslation: null,
+          templateVariables: []
+        });
       } else {
         const templateTranslation = template.translations[0];
         const templateVariables =


### PR DESCRIPTION
## Summary
- Selecting the "Expression" option in the template dropdown of the SendMsg action threw `TypeError: Cannot read properties of undefined (reading 'value')` because `handleTemplateChanged` read `this.state.expression.value` without guarding against `expression` being `null` (its initial state, and the state set when a non-Expression template is selected).
- Also clear stale `templateTranslation` and `templateVariables` when switching to Expression so the previously-selected template's variable inputs don't linger.

## Changes
- `floweditor/src/components/flow/actions/sendmsg/SendMsgForm.tsx`: in the `template.name === 'Expression'` branch of `handleTemplateChanged`, default the expression value to `''` when `this.state.expression` is null, and reset `templateTranslation` / `templateVariables`. `template.value` is intentionally kept set to the Expression option so the message-required validator (which fires when there is no template and no attachments) doesn't block save.

## Test plan
- [ ] Open a SendMsg node, select "Expression" from the template dropdown — input appears, no console error.
- [ ] Type an expression and click Save — saves without "message is required" / validation errors.
- [ ] Select a real template first (with variables), then switch to Expression — variable inputs disappear and the expression input shows empty.
- [ ] Reopen the saved node — Expression input is restored with the previously entered value.
- [ ] Switch from Expression back to a regular template — expression input disappears and template variables render.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Template switching in message forms now properly resets related fields when the Expression template is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->