### PR TITLE
Reject a webhook wait_time over the 5 minute cap in the node editor

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/amishabisht/projects/floweditor/node_modules

--- a/src/components/flow/routers/webhook/WebhookRouterForm.tsx
+++ b/src/components/flow/routers/webhook/WebhookRouterForm.tsx
@@ -11,6 +11,7 @@ import {
   stateToNode,
   getDefaultBody,
   isValidJson,
+  isWaitTimeWithinCap,
   fetchWebhookOptions
 } from 'components/flow/routers/webhook/helpers';
 import { createResultNameInput } from 'components/flow/routers/widgets';
@@ -205,7 +206,7 @@ export default class WebhookRouterForm extends React.Component<
       if (isFunction && keys.body.trim() === '') {
         updates.body = { value: keys.body };
       } else {
-        updates.body = validate('POST body', keys.body, [isValidJson()]);
+        updates.body = validate('POST body', keys.body, [isValidJson(), isWaitTimeWithinCap()]);
       }
     }
 

--- a/src/components/flow/routers/webhook/helpers.test.ts
+++ b/src/components/flow/routers/webhook/helpers.test.ts
@@ -1,0 +1,57 @@
+import {
+  isWaitTimeWithinCap,
+  WAIT_TIME_CAP_SECONDS
+} from 'components/flow/routers/webhook/helpers';
+
+const failuresFor = (body: string) => isWaitTimeWithinCap()('POST body', body).failures;
+const messageFor = (body: string) => failuresFor(body)[0].message;
+
+describe('isWaitTimeWithinCap', () => {
+  it('accepts a wait_time inside the cap', () => {
+    expect(failuresFor('{"speech": "", "wait_time": 240}')).toEqual([]);
+    expect(failuresFor('{"wait_time": "240"}')).toEqual([]);
+    expect(failuresFor(`{"wait_time": ${WAIT_TIME_CAP_SECONDS}}`)).toEqual([]);
+  });
+
+  it('accepts a body that says nothing about wait_time', () => {
+    expect(failuresFor('{"speech": "@results.audio"}')).toEqual([]);
+  });
+
+  it('accepts the blank wait_time the body template ships', () => {
+    expect(failuresFor('{"speech": "", "wait_time": ""}')).toEqual([]);
+    expect(failuresFor('{"wait_time": "   "}')).toEqual([]);
+    expect(failuresFor('{"wait_time": null}')).toEqual([]);
+  });
+
+  it('rejects a wait_time over the cap', () => {
+    expect(messageFor('{"wait_time": 600}')).toContain('cannot be more than 300 seconds');
+    expect(messageFor(`{"wait_time": ${WAIT_TIME_CAP_SECONDS + 1}}`)).toContain('5 minutes');
+  });
+
+  it('rejects a wait_time that is not a positive whole number', () => {
+    ['0', '-30', '"abc"', '"60s"', '12.5'].forEach(value => {
+      expect(messageFor(`{"wait_time": ${value}}`)).toContain('whole number');
+    });
+  });
+
+  it('rejects a non-scalar wait_time', () => {
+    ['{}', '[]', 'true'].forEach(value => {
+      expect(failuresFor(`{"wait_time": ${value}}`).length).toBe(1);
+    });
+  });
+
+  it('stays quiet on an undecodable body, which isValidJson already reports', () => {
+    expect(failuresFor('not json at all')).toEqual([]);
+    expect(failuresFor('')).toEqual([]);
+  });
+
+  it('stays quiet on json that is not an object', () => {
+    expect(failuresFor('[1, 2]')).toEqual([]);
+    expect(failuresFor('"a string"')).toEqual([]);
+  });
+
+  it('always returns the body unchanged as the entry value', () => {
+    const body = '{"wait_time": 600}';
+    expect(isWaitTimeWithinCap()('POST body', body).value).toBe(body);
+  });
+});

--- a/src/components/flow/routers/webhook/helpers.ts
+++ b/src/components/flow/routers/webhook/helpers.ts
@@ -4,7 +4,7 @@ import { DEFAULT_BODY } from 'components/nodeeditor/constants';
 import { Operators, Types } from 'config/interfaces';
 import { CallWebhook, SwitchRouter } from 'flowTypes';
 import { RenderNode } from 'store/flowContext';
-import { NodeEditorSettings, StringEntry } from 'store/nodeEditor';
+import { NodeEditorSettings, StringEntry, ValidationFailure } from 'store/nodeEditor';
 import { ValidatorFunc } from 'store/validators';
 import { createUUID } from 'utils';
 import axios from 'axios';
@@ -203,6 +203,56 @@ export const fetchWebhookOptions = async (
   }
 
   return stateUpdate;
+};
+
+// Async webhook nodes park the flow until their callback arrives. Glific caps that park at
+// 5 minutes (Glific.Flows.Action), reading `wait_time` straight out of this body, so catch an
+// over-cap value here rather than letting the backend silently clamp it on publish.
+export const WAIT_TIME_CAP_SECONDS = 300;
+
+export const isWaitTimeWithinCap = (): ValidatorFunc => (name, body: any) => {
+  const pass = { failures: [] as ValidationFailure[], value: body };
+
+  let parsed: any;
+  try {
+    parsed = JSON.parse(body);
+  } catch (e) {
+    // isValidJson already reports an undecodable body; don't double up on it.
+    return pass;
+  }
+
+  if (!parsed || typeof parsed !== 'object' || !('wait_time' in parsed)) {
+    return pass;
+  }
+
+  const waitTime = parsed.wait_time;
+  const trimmed = typeof waitTime === 'string' ? waitTime.trim() : waitTime;
+
+  // The webhook body template ships wait_time blank; that means "use the default".
+  if (trimmed === '' || trimmed === null || trimmed === undefined) {
+    return pass;
+  }
+
+  const fail = (message: string) => ({
+    failures: [{ message }] as ValidationFailure[],
+    value: body
+  });
+
+  if (typeof trimmed !== 'number' && typeof trimmed !== 'string') {
+    return fail('wait_time must be a number of seconds');
+  }
+
+  const seconds = Number(trimmed);
+
+  if (!Number.isInteger(seconds) || seconds <= 0) {
+    return fail('wait_time must be a whole number of seconds greater than 0');
+  }
+
+  if (seconds > WAIT_TIME_CAP_SECONDS) {
+    return fail(`wait_time cannot be more than ${WAIT_TIME_CAP_SECONDS} seconds (5 minutes)`);
+  }
+
+  return pass;
 };
 
 export const isValidJson = (): ValidatorFunc => (name, body: any) => {


### PR DESCRIPTION
Companion to glific/glific#5638 (issue glific/glific#5633). Backend-side, an async webhook node can now set its own await window via `wait_time` in the webhook body, capped at 5 minutes.

## Why

Without this, an over-cap value is only caught at **publish**, as a Warning, *after* the backend has already silently clamped it. So the node behaves differently from what the author typed, and they find out late — or never, if they only ever test in the simulator.

## What

Adds an `isWaitTimeWithinCap()` validator in `webhook/helpers.ts` and wires it into the body's existing validation in `WebhookRouterForm`:

```ts
updates.body = validate('POST body', keys.body, [isValidJson(), isWaitTimeWithinCap()]);
```

`mergeForm` folds body failures into the form's `valid` flag and `handleSave` gates on it, so this both shows the message under the body field (same place as "Not a valid JSON") **and blocks Ok** until it's fixed. Stronger than the backend warning: the bad value can't be saved at all.

## Behaviour

| Body | Result |
|---|---|
| `{"wait_time": 240}` / `"240"` / `300` | accepted |
| no `wait_time` key | accepted |
| `{"wait_time": ""}` — what the body template ships | accepted, means "use the webhook's default" |
| `{"wait_time": 600}` | `wait_time cannot be more than 300 seconds (5 minutes)` |
| `0`, `-30`, `"abc"`, `"60s"`, `12.5` | `wait_time must be a whole number of seconds greater than 0` |
| `{}`, `[]`, `true` | `wait_time must be a number of seconds` |
| undecodable body | silent — `isValidJson()` already reports it, no double error |

## Testing

New `webhook/helpers.test.ts` — 9 tests covering the table above plus that the entry value is returned unchanged. All webhook suites pass: 4 suites, 19 tests, 15 snapshots. Prettier clean. `tsc --noEmit` reports no errors in the changed files (the repo has 36 pre-existing TS7018 errors in other test files, untouched).

## Note for the reviewer

`isValidJson()` just above has a latent bug — no `return` when `JSON.parse` succeeds on a non-object (`"123"`, `true`), so it falls through to `undefined`, and `validate()` then reads `.failures` off it. Not touched here, but worth a separate fix. The new validator is written total to avoid the same trap.

## Release path

This needs a published `@glific/flow-editor` version and a bump of the pin in glific-frontend (currently `1.43.0-14`) before NGOs see it.